### PR TITLE
Grunt on windows

### DIFF
--- a/.github/workflows/grunt.yml
+++ b/.github/workflows/grunt.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         java: [17]
         node: [16]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/grunt.yml
+++ b/.github/workflows/grunt.yml
@@ -7,6 +7,8 @@ concurrency:
   cancel-in-progress: true
 jobs:
   build:
+    env:
+      JAVA_TOOL_OPTIONS: -Dfile.encoding=UTF8
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]

--- a/.github/workflows/grunt.yml
+++ b/.github/workflows/grunt.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         java: [17]
         node: [16]
     runs-on: ${{ matrix.os }}

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -72,11 +72,17 @@ module.exports = function mvnwSync(args) {
   console.debug('+ %s', cmd);
   const result = spawnSync(
     bin,
-    params.map(p => (process.platform == "win32") ? `"${p}"` : p),
+    params.map((p) => (process.platform == 'win32') ? `"${p}"` : p),
     {
       cwd: home,
       stdio: 'inherit',
-      shell: process.platform == 'win32' ? 'C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe' : undefined 
+      shell: (
+        process.platform == 'win32'
+        ?
+        'C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe'
+        :
+        undefined
+      ),
     }
   );
   if (result.status != 0) {

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -70,7 +70,15 @@ module.exports = function mvnwSync(args) {
   ]);
   const cmd = bin + ' ' + params.join(' ');
   console.debug('+ %s', cmd);
-  const result = spawnSync(bin, params, {cwd: home, stdio: 'inherit'});
+  const result = spawnSync(
+    bin + (process.platform == 'win32' ? '.cmd' : ''),
+    params,
+    {
+      cwd: home,
+      stdio: 'inherit',
+      shell: process.platform == 'win32' ? 'C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe' : undefined 
+    }
+  );
   if (result.status != 0) {
     throw new Error('The command "' + cmd + '" exited with #' + result.status + ' code');
   }

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -58,7 +58,7 @@ function latest() {
  */
 module.exports = function mvnwSync(args) {
   const home = path.resolve(__dirname, '../mvnw');
-  const bin = path.resolve(home, 'mvnw');
+  const bin = path.resolve(home, 'mvnw') + (process.platform == 'win32' ? '.cmd' : '');
   const params = args.filter(function(t) {
     return t != '';
   }).concat([
@@ -71,7 +71,7 @@ module.exports = function mvnwSync(args) {
   const cmd = bin + ' ' + params.join(' ');
   console.debug('+ %s', cmd);
   const result = spawnSync(
-    bin + (process.platform == 'win32' ? '.cmd' : ''),
+    bin,
     params.map(p => (process.platform == "win32") ? `"${p}"` : p),
     {
       cwd: home,

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -72,7 +72,7 @@ module.exports = function mvnwSync(args) {
   console.debug('+ %s', cmd);
   const result = spawnSync(
     bin + (process.platform == 'win32' ? '.cmd' : ''),
-    params,
+    params.map(p => (process.platform == "win32") ? `"${p}"` : p),
     {
       cwd: home,
       stdio: 'inherit',


### PR DESCRIPTION
Fix #7 

Run `mvnw.cmd` instead of `mvnw` on windows, run it via powershell. Wrap all command arguments with quotes because if not, maven does not understand that `-Darg.one` is `arg.one` and tries to find a group named `.one`.