### PR TITLE
#85: Add .xml extension for graph generated file

### DIFF
--- a/test/commands/test_gmi.js
+++ b/test/commands/test_gmi.js
@@ -47,7 +47,7 @@ describe('gmi', function() {
         'target/gmi/simple.gmi',
         'target/gmi/simple.gmi.xml',
         'target/gmi/simple.gmi.xe',
-        'target/gmi/simple.gmi.graph',
+        'target/gmi/simple.gmi.graph.xml',
         'target/gmi/simple.gmi.dot',
       ]
     );


### PR DESCRIPTION
`GmiMojo` adds `.xml` extension for generated `graph` files. I added `.xml` extension for tests in order to make them pass. [Link](https://github.com/objectionary/eo/blob/67e5087459eda1d882a7e23f664bc7164e97a5bc/eo-maven-plugin/src/main/java/org/eolang/maven/GmiMojo.java#L385). 
Issue: #85