### PR TITLE
sync-request instead of XHR

### DIFF
--- a/.rultor.yml
+++ b/.rultor.yml
@@ -12,9 +12,9 @@ install: |
 release:
   script: |
     [[ "${tag}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || exit -1
-    sed -i -e "s/0.0.0/${tag}/" package.json
-    sed -i -e "s/0.0.0/${tag}/" src/version.js
-    sed -i -e "s/0000-00-00/$(date +%Y-%m-%d)/" src/version.js
+    sed -i "s/0.0.0/${tag}/" package.json
+    sed -i "s/0.0.0/${tag}/" src/version.js
+    sed -i "s/0000-00-00/$(date +%Y-%m-%d)/" src/version.js
     grunt --no-color
     git commit -am "set version to ${tag}"
     chmod 600 ../npmrc

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "commander": "10.0.1",
     "fast-xml-parser": "4.2.2",
     "node": "20.2.0",
+    "sync-request": "6.1.0",
     "xmlhttprequest": "1.8.0"
   },
   "devDependencies": {

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -43,12 +43,9 @@ if (process.argv.includes('--verbose')) {
   console.debug('Debug output is turned ON');
 }
 
+let parser = '0.29.4';
 if (process.argv.includes('--latest')) {
-  const ver = require('./parser-version').get();
-  process.argv.push('--parser');
-  process.argv.push(ver);
-  process.argv.push('--hash');
-  process.argv.push(ver);
+  parser = require('./parser-version').get();
 }
 
 const version = require('./version');
@@ -57,7 +54,6 @@ program
   .description('EO command-line toolkit (' + version.what + ' ' + version.when + ')')
   .version(version.what);
 
-const parser = '0.29.4';
 program
   .option('-s, --sources <path>', 'Directory with .EO sources', '.')
   .option('-t, --target <path>', 'Directory with all generated files', '.eoc')

--- a/src/parser-version.js
+++ b/src/parser-version.js
@@ -22,8 +22,8 @@
  * SOFTWARE.
  */
 
-const XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest;
 const {XMLParser} = require('fast-xml-parser');
+const request = require('sync-request');
 
 /**
  * Load the latest version from GitHub releases.
@@ -34,17 +34,14 @@ const version = module.exports = {
   get: function() {
     if (version.value === '') {
       const repo = 'org/eolang/eo-maven-plugin';
-      const url = 'https://repo.maven.apache.org/maven2/' + repo + '/maven-metadata.xml';
-      const xhr = new XMLHttpRequest();
-      xhr.open('GET', url, false);
-      xhr.send(null);
-      if (xhr.status != 200) {
-        throw new Error('Invalid response status ' + xhr.status + ' from ' + url);
+      const url = `https://repo.maven.apache.org/maven2/${repo}/maven-metadata.xml`;
+      const res = request('GET', url, {timeout: 100000, socketTimeout: 100000});
+      if (res.statusCode != 200) {
+        throw new Error(`Invalid response status #${res.statusCode} from ${url}: ${res.body}`);
       }
-      const xml = new XMLParser().parse(xhr.responseText);
+      const xml = new XMLParser().parse(res.body);
       version.value = xml.metadata.versioning.release;
-      console.debug('The latest version of %s at %s is %s', repo, url, version.value);
-      console.info('EO version is %s', version.value);
+      console.info('The latest version of %s at %s is %s', repo, url, version.value);
     }
     return version.value;
   }

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -42,7 +42,7 @@ describe('eoc', function() {
   });
 
   it('loads latest version', function(done) {
-    runSync(['--latest', '--version']);
+    const stdout = runSync(['--latest', '--version']);
     assert(!stdout.includes('29.0.4'));
     done();
   });

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -43,6 +43,7 @@ describe('eoc', function() {
 
   it('loads latest version', function(done) {
     runSync(['--latest', '--version']);
+    assert(!stdout.includes('29.0.4'));
     done();
   });
 });


### PR DESCRIPTION
per #146

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `sync-request` and removes `xmlhttprequest` as a dependency. It also refactors the `parser-version.js` module to use `sync-request` instead of `xmlhttprequest`.

### Detailed summary
- Adds `sync-request` and removes `xmlhttprequest` as a dependency in `package.json`
- Refactors `parser-version.js` to use `sync-request` instead of `xmlhttprequest`
- Replaces `runSync` with `stdout` and `assert` in `test_eoc.js` 
- Minor changes in `.rultor.yml` and `eoc.js`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->