### PR TITLE
"print" command

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ There are also commands that help manipulate with XMIR and EO sources
   * `sodg` generates SODG from XMIR, further rederable as XML or [Dot](https://en.wikipedia.org/wiki/DOT_%28graph_description_language%29)
   * `phi` generates PHI files from XMIR
   * `unphi` generates XMIR files from PHI files
+  * `print` generates EO files from PHI files
   * <del>`translate` converts Java/C++/Python/etc. program to EO program</del>
   * <del>`demu` removes `cage` and `memory` objects</del>
   * <del>`dejump` removes `goto` objects</del>

--- a/src/commands/print.js
+++ b/src/commands/print.js
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const path = require('path');
+const {mvnw, flags} = require('../mvnw');
+
+/**
+ * Command to convert .XMIR files into .EO files.
+ * @param {Hash} opts - All options
+ * @return {Promise} of assemble task
+ */
+module.exports = function(opts) {
+  const input = path.resolve(opts.target, '2-optimize');
+  console.debug('Reading from %s', input);
+  const output = path.resolve(opts.target, 'print');
+  console.debug('Writing into %s', output);
+  return mvnw(
+    ['eo:print']
+      .concat(flags(opts))
+      .concat(
+        [
+          `-Deo.printSourcesDir=${input}`,
+          `-Deo.printOutputDir=${output}`,
+        ]
+      ),
+    opts.target, opts.batch
+  ).then((r) => {
+    console.info('XMIR files converted into EO files at %s', output);
+    return r;
+  });
+};

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -32,6 +32,7 @@ const assemble = require('./commands/assemble');
 const sodg = require('./commands/sodg');
 const phi = require('./commands/phi');
 const unphi = require('./commands/unphi');
+const print = require('./commands/print');
 const register = require('./commands/register');
 const verify = require('./commands/verify');
 const transpile = require('./commands/transpile');
@@ -165,6 +166,13 @@ program.command('unphi')
   .action((str, opts) => {
     clear(str);
     unphi(program.opts());
+  });
+
+program.command('print')
+  .description('Generate EO files from XMIR files')
+  .action((str, opts) => {
+    clear(str);
+    print(program.opts());
   });
 
 program.command('verify')

--- a/test/commands/test_print.js
+++ b/test/commands/test_print.js
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2023 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {runSync, assertFilesExist} = require('../helpers');
+
+describe('print', function() {
+  it('converts XMIR files to EO files', function(done) {
+    home = path.resolve('temp/test-print/simple');
+    fs.rmSync(home, {recursive: true, force: true});
+    fs.mkdirSync(path.resolve(home, 'target/2-optimize'), {recursive: true});
+    fs.writeFileSync(
+      path.resolve(home, 'target/2-optimize/app.xmir'),
+      '<program><objects/></program>'
+    );
+    const stdout = runSync([
+      'print',
+      '--verbose',
+      '--track-optimization-steps',
+      '--parser=0.34.1',
+      '--hash=1d605bd872f27494551e9dd2341b9413d0d96d89',
+      '-t', path.resolve(home, 'target'),
+    ]);
+    assertFilesExist(
+      stdout, home,
+      [
+        'target/print/app.eo',
+      ]
+    );
+    done();
+  });
+});


### PR DESCRIPTION
see #214 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
This PR adds a new command `print` that generates EO files from XMIR files. It also includes the necessary code and test files for the `print` command. 

Notable changes:
- Added `print` command to generate EO files from XMIR files
- Created `print.js` file with the implementation of the `print` command
- Added test file `test_print.js` to test the `print` command functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->