### PR TITLE
Eslint modified to warn against implicitly declared variables and functions.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -6,7 +6,8 @@
   "rules": {
     "comma-dangle": "off",
     "indent": [ "error", 2 ],
-    "max-len": [ "error", { "code": 100 } ]
+    "max-len": [ "error", { "code": 100 } ],
+    "no-implicit-globals": "warn"
   },
   "parserOptions": {
     "ecmaVersion": 2019

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -168,7 +168,7 @@ function print() {
   function count(dir, curr) {
     if (fs.existsSync(dir)) {
       for (const f of fs.readdirSync(dir)) {
-        next = path.join(dir, f);
+        const next = path.join(dir, f);
         if (fs.statSync(next).isDirectory()) {
           curr = count(next, curr);
         } else {


### PR DESCRIPTION
Closes #262 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates `mvnw.js` to define `next` variable and adds `no-implicit-globals` rule in `.eslintrc.json`.

### Detailed summary
- Defined `next` variable in `mvnw.js` for readability.
- Added `no-implicit-globals` rule in `.eslintrc.json` with a warning level.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->