### PR TITLE
feat(#288): integrate eo2js with eoc

### DIFF
--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -34,6 +34,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
         java: [11, 18]
         node: [12, 16]
+        lang: [Java, JavaScript]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -50,9 +51,9 @@ jobs:
           p=0.36.0
           t=0.36.0
           node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch \
-            dataize program
+            "-l=${{ matrix.lang }}" dataize program
           node ../src/eoc.js "--parser=$p" "--home-tag=$t" --alone \
-            --batch dataize program
+            "-l=${{ matrix.lang }}" --batch dataize program
           node ../src/eoc.js clean
           node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch \
-            test
+            "-l=${{ matrix.lang }}" test

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         java: [11, 18]
-        node: [12, 16]
+        node: [14, 16]
         lang: [Java, JavaScript]
         exclude:
           - os: macos-latest

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -27,6 +27,9 @@ name: itest
 concurrency:
   group: itest-${{ github.ref }}
   cancel-in-progress: true
+env:
+  parser: 0.38.0
+  tag: 0.38.0
 jobs:
   build:
     strategy:
@@ -51,24 +54,22 @@ jobs:
       - run: npm install
       - run: |
           cd itest
-          p=0.38.0
-          t=0.38.0
-          node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch \
+          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --batch \
             "--language=${{ matrix.lang }}" dataize program
-          node ../src/eoc.js "--parser=$p" "--home-tag=$t" --alone \
+          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --alone \
             "--language=${{ matrix.lang }}" --batch dataize program
           node ../src/eoc.js clean
-          node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch \
+          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --batch \
             "--language=${{ matrix.lang }}" test
         if: ${{ matrix.os != 'windows-latest' }}
       - run: |
           cd itest
-          node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch `
+          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --batch `
             "--language=${{ matrix.lang }}" dataize program
-          node ../src/eoc.js "--parser=$p" "--home-tag=$t" --alone `
+          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --alone `
             "--language=${{ matrix.lang }}" --batch dataize program
           node ../src/eoc.js clean
-          node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch `
+          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --batch `
             "--language=${{ matrix.lang }}" test
         shell: pwsh
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -54,22 +54,22 @@ jobs:
       - run: npm install
       - run: |
           cd itest
-          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --batch \
-            "--language=${{ matrix.lang }}" dataize program
-          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --alone \
-            "--language=${{ matrix.lang }}" --batch dataize program
+          node ../src/eoc.js "--parser=$PARSER" "--home-tag=${{ env.TAG }}" \
+            --batch "--language=${{ matrix.lang }}" dataize program
+          node ../src/eoc.js "--parser=$PARSER" "--home-tag=${{ env.TAG }}" \
+            --alone "--language=${{ matrix.lang }}" --batch dataize program
           node ../src/eoc.js clean
-          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --batch \
-            "--language=${{ matrix.lang }}" test
+          node ../src/eoc.js "--parser=$PARSER" "--home-tag=${{ env.TAG }}" \
+            --batch "--language=${{ matrix.lang }}" test
         if: ${{ matrix.os != 'windows-latest' }}
       - run: |
           cd itest
-          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --batch `
-            "--language=${{ matrix.lang }}" dataize program
-          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --alone `
-            "--language=${{ matrix.lang }}" --batch dataize program
+          node ../src/eoc.js "--parser=$PARSER" "--home-tag=${{ env.TAG }}" `
+            --batch "--language=${{ matrix.lang }}" dataize program
+          node ../src/eoc.js "--parser=$PARSER" "--home-tag=${{ env.TAG }}" `
+            --alone "--language=${{ matrix.lang }}" --batch dataize program
           node ../src/eoc.js clean
-          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --batch `
-            "--language=${{ matrix.lang }}" test
+          node ../src/eoc.js "--parser=$PARSER" "--home-tag=${{ env.TAG }}" `
+            --batch "--language=${{ matrix.lang }}" test
         shell: pwsh
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -64,12 +64,14 @@ jobs:
         if: ${{ matrix.os != 'windows-latest' }}
       - run: |
           cd itest
-          node ../src/eoc.js "--parser=$PARSER" "--home-tag=${{ env.TAG }}" `
+          $Parser = "${{ env.PARSER }}"
+          $Tag = "${{ env.TAG }}"
+          node ../src/eoc.js "--parser=$Parser" "--home-tag=$Tag" `
             --batch "--language=${{ matrix.lang }}" dataize program
-          node ../src/eoc.js "--parser=$PARSER" "--home-tag=${{ env.TAG }}" `
+          node ../src/eoc.js "--parser=$Parser" "--home-tag=$Tag" `
             --alone "--language=${{ matrix.lang }}" --batch dataize program
           node ../src/eoc.js clean
-          node ../src/eoc.js "--parser=$PARSER" "--home-tag=${{ env.TAG }}" `
+          node ../src/eoc.js "--parser=$Parser" "--home-tag=$Tag" `
             --batch "--language=${{ matrix.lang }}" test
         shell: pwsh
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -28,8 +28,8 @@ concurrency:
   group: itest-${{ github.ref }}
   cancel-in-progress: true
 env:
-  parser: 0.38.0
-  tag: 0.38.0
+  PARSER: 0.38.0
+  TAG: 0.38.0
 jobs:
   build:
     strategy:
@@ -54,22 +54,22 @@ jobs:
       - run: npm install
       - run: |
           cd itest
-          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --batch \
+          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --batch \
             "--language=${{ matrix.lang }}" dataize program
-          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --alone \
+          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --alone \
             "--language=${{ matrix.lang }}" --batch dataize program
           node ../src/eoc.js clean
-          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --batch \
+          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --batch \
             "--language=${{ matrix.lang }}" test
         if: ${{ matrix.os != 'windows-latest' }}
       - run: |
           cd itest
-          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --batch `
+          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --batch `
             "--language=${{ matrix.lang }}" dataize program
-          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --alone `
+          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --alone `
             "--language=${{ matrix.lang }}" --batch dataize program
           node ../src/eoc.js clean
-          node ../src/eoc.js "--parser=$parser" "--home-tag=$tag" --batch `
+          node ../src/eoc.js "--PARSER=$PARSER" "--home-TAG=${{ env.TAG }}" --batch `
             "--language=${{ matrix.lang }}" test
         shell: pwsh
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -51,8 +51,8 @@ jobs:
       - run: npm install
       - run: |
           cd itest
-          p=0.36.0
-          t=0.36.0
+          p=0.38.0
+          t=0.38.0
           node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch \
             "--language=${{ matrix.lang }}" dataize program
           node ../src/eoc.js "--parser=$p" "--home-tag=$t" --alone \

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -54,21 +54,21 @@ jobs:
           p=0.36.0
           t=0.36.0
           node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch \
-            "-l=${{ matrix.lang }}" dataize program
+            "--language=${{ matrix.lang }}" dataize program
           node ../src/eoc.js "--parser=$p" "--home-tag=$t" --alone \
-            "-l=${{ matrix.lang }}" --batch dataize program
+            "--language=${{ matrix.lang }}" --batch dataize program
           node ../src/eoc.js clean
           node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch \
-            "-l=${{ matrix.lang }}" test
+            "--language=${{ matrix.lang }}" test
         if: ${{ matrix.os != 'windows-latest' }}
       - run: |
           cd itest
-          node ../src/eoc.js "--parser=0.36.0" "--home-tag=0.36.0" --batch `
-            "-l=${{ matrix.lang }}" dataize program
-          node ../src/eoc.js "--parser=0.36.0" "--home-tag=0.36.0" --alone `
-            "-l=${{ matrix.lang }}" --batch dataize program
+          node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch `
+            "--language=${{ matrix.lang }}" dataize program
+          node ../src/eoc.js "--parser=$p" "--home-tag=$t" --alone `
+            "--language=${{ matrix.lang }}" --batch dataize program
           node ../src/eoc.js clean
-          node ../src/eoc.js "--parser=0.36.0" "--home-tag=0.36.0" --batch `
-            "-l=${{ matrix.lang }}" test
+          node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch `
+            "--language=${{ matrix.lang }}" test
         shell: pwsh
         if: ${{ matrix.os == 'windows-latest' }}

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -35,6 +35,9 @@ jobs:
         java: [11, 18]
         node: [12, 16]
         lang: [Java, JavaScript]
+        exclude:
+          - os: macos-latest
+            node: 14
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
@@ -57,3 +60,15 @@ jobs:
           node ../src/eoc.js clean
           node ../src/eoc.js "--parser=$p" "--home-tag=$t" --batch \
             "-l=${{ matrix.lang }}" test
+        if: ${{ matrix.os != 'windows-latest' }}
+      - run: |
+          cd itest
+          node ../src/eoc.js "--parser=0.36.0" "--home-tag=0.36.0" --batch `
+            "-l=${{ matrix.lang }}" dataize program
+          node ../src/eoc.js "--parser=0.36.0" "--home-tag=0.36.0" --alone `
+            "-l=${{ matrix.lang }}" --batch dataize program
+          node ../src/eoc.js clean
+          node ../src/eoc.js "--parser=0.36.0" "--home-tag=0.36.0" --batch `
+            "-l=${{ matrix.lang }}" test
+        shell: pwsh
+        if: ${{ matrix.os == 'windows-latest' }}

--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,7 @@
 .github/
 .pdd
 .rultor.yml
-Gruntfile.js
+Gruntfile.eo2jsw
 test/
 node_modules/
 temp/

--- a/.npmignore
+++ b/.npmignore
@@ -5,7 +5,7 @@
 .github/
 .pdd
 .rultor.yml
-Gruntfile.eo2jsw
+Gruntfile.js
 test/
 node_modules/
 temp/

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ First, run `npm install`. Then, run `grunt`. All tests should pass.
 If you want to run a single test:
 
 ```bash
-npm test -- test/test_mvnw.js
+npm test -- test/test_mvnw.eo2jsw
 ```
 
 Make your changes and then
@@ -82,6 +82,6 @@ a pull request.
 
 [npm]: https://www.npmjs.com/package/eolang
 [java-se]: https://www.oracle.com/java/technologies/downloads/
-[npm-install]: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
+[npm-install]: https://docs.npmjs.com/downloading-and-installing-node-eo2jsw-and-npm
 [dot]: https://en.wikipedia.org/wiki/DOT_%28graph_description_language%29
 [blog]: https://www.yegor256.com/2021/10/21/objectionary.html

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ First, run `npm install`. Then, run `grunt`. All tests should pass.
 If you want to run a single test:
 
 ```bash
-npm test -- test/test_mvnw.eo2jsw
+npm test -- test/test_mvnw.js
 ```
 
 Make your changes and then
@@ -82,6 +82,6 @@ a pull request.
 
 [npm]: https://www.npmjs.com/package/eolang
 [java-se]: https://www.oracle.com/java/technologies/downloads/
-[npm-install]: https://docs.npmjs.com/downloading-and-installing-node-eo2jsw-and-npm
+[npm-install]: https://docs.npmjs.com/downloading-and-installing-node-js-and-npm
 [dot]: https://en.wikipedia.org/wiki/DOT_%28graph_description_language%29
 [blog]: https://www.yegor256.com/2021/10/21/objectionary.html

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "dependencies": {
         "colors": "1.4.0",
         "commander": "12.0.0",
+        "eo2js": "0.0.5",
         "fast-xml-parser": "4.3.6",
         "node": "22.1.0",
         "relative": "3.0.2",
@@ -365,6 +366,29 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -713,6 +737,19 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
+    },
+    "node_modules/eo2js": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/eo2js/-/eo2js-0.0.5.tgz",
+      "integrity": "sha512-tNI4KfN/s245J2Et12kqHJ1VmP/53cLbbYrIagYXUF3Qs2fvmsuCeuX4aeJQuZbhiUfspRyAeirOlBM/vHwn0A==",
+      "dependencies": {
+        "commander": "^12.0.0",
+        "fast-xml-parser": "^4.3.5",
+        "saxon-js": "^2.6.0"
+      },
+      "bin": {
+        "eo2js": "src/eo2js.js"
+      }
     },
     "node_modules/es-define-property": {
       "version": "1.0.0",
@@ -1105,6 +1142,25 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.1.tgz",
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/for-in": {
       "version": "1.0.2",
@@ -2907,6 +2963,11 @@
         "asap": "~2.0.6"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3142,6 +3203,14 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "node_modules/saxon-js": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/saxon-js/-/saxon-js-2.6.0.tgz",
+      "integrity": "sha512-4dinQEGz/OQX0cnmwLTbjVFY9KciMGRyfA6AUsMCO/mKDOwDxOJFmzoLStieTpEiOB/98E1E4VKV1ElsiD88yQ==",
+      "dependencies": {
+        "axios": "^1.5.1"
+      }
     },
     "node_modules/semver": {
       "version": "7.6.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "dependencies": {
     "colors": "1.4.0",
+    "eo2js": "0.0.5",
     "commander": "12.0.0",
     "fast-xml-parser": "4.3.6",
     "node": "22.1.0",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "colors": "1.4.0",
-    "eo2js": "0.0.5",
+    "eo2js": "0.0.6",
     "commander": "12.0.0",
     "fast-xml-parser": "4.3.6",
     "node": "22.1.0",

--- a/src/commands/java/compile.js
+++ b/src/commands/java/compile.js
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const rel = require('relative');
+const {mvnw, flags} = require('../../mvnw');
+const path = require('path');
+
+/**
+ * Command to compile target language into binaries.
+ * @param {Object} opts - All options
+ * @return {Promise} of compile task
+ */
+module.exports = function(opts) {
+  const target = path.resolve(opts.target);
+  return mvnw(['compiler:compile'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
+    console.info('Java .class files compiled into %s', rel(target));
+    return r;
+  });
+};

--- a/src/commands/java/dataize.js
+++ b/src/commands/java/dataize.js
@@ -22,13 +22,28 @@
  * SOFTWARE.
  */
 
-const {mvnw, flags} = require('../mvnw');
+const {spawn} = require('node:child_process');
+const path = require('path');
 
 /**
- * Command to run all available unit tests.
- * @param {Hash} opts - All options
- * @return {Promise} of compile task
+ * Runs the single executable binary.
+ * @param {String} obj - Name of object to dataize
+ * @param {Array} args - Arguments
+ * @param {Object} opts - All options
  */
-module.exports = function(opts) {
-  return mvnw(['surefire:test'].concat(flags(opts)));
+module.exports = function(obj, args, opts) {
+  const params = [
+    '-Dfile.encoding=UTF-8',
+    `-Xss${opts.stack}`,
+    '-jar', path.resolve(opts.target, 'eoc.jar'),
+    obj,
+    ...args,
+  ];
+  console.debug('+ java ' + params.join(' '));
+  spawn('java', params, {stdio: 'inherit'}).on('close', (code) => {
+    if (code !== 0) {
+      console.error(`Java exited with #${code} code`);
+      process.exit(1);
+    }
+  });
 };

--- a/src/commands/java/link.js
+++ b/src/commands/java/link.js
@@ -22,28 +22,19 @@
  * SOFTWARE.
  */
 
-const {spawn} = require('node:child_process');
+const rel = require('relative');
+const {mvnw, flags} = require('../../mvnw');
 const path = require('path');
 
 /**
- * Runs the single executable binary.
- * @param {String} obj - Name of object to dataize
- * @param {Array} args - Arguments
- * @param {Hash} opts - All options
+ * Command to link binaries into a single executable binary.
+ * @param {Object} opts - All options
+ * @return {Promise} of link task
  */
-module.exports = function(obj, args, opts) {
-  const params = [
-    '-Dfile.encoding=UTF-8',
-    `-Xss${opts.stack}`,
-    '-jar', path.resolve(opts.target, 'eoc.jar'),
-    obj,
-    ...args,
-  ];
-  console.debug('+ java ' + params.join(' '));
-  spawn('java', params, {stdio: 'inherit'}).on('close', (code) => {
-    if (code !== 0) {
-      console.error(`Java exited with #${code} code`);
-      process.exit(1);
-    }
+module.exports = function(opts) {
+  const jar = path.resolve(opts.target, 'eoc.jar');
+  return mvnw(['jar:jar'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
+    console.info('Executable JAR created at %s', rel(jar));
+    return r;
   });
 };

--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -22,19 +22,13 @@
  * SOFTWARE.
  */
 
-const rel = require('relative');
-const {mvnw, flags} = require('../mvnw');
-const path = require('path');
+const {mvnw, flags} = require('../../mvnw');
 
 /**
- * Command to compile target language into binaries.
- * @param {Hash} opts - All options
+ * Command to run all available unit tests.
+ * @param {Object} opts - All options
  * @return {Promise} of compile task
  */
 module.exports = function(opts) {
-  const target = path.resolve(opts.target);
-  return mvnw(['compiler:compile'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
-    console.info('Java .class files compiled into %s', rel(target));
-    return r;
-  });
+  return mvnw(['surefire:test'].concat(flags(opts)));
 };

--- a/src/commands/java/transpile.js
+++ b/src/commands/java/transpile.js
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const rel = require('relative');
+const {mvnw, flags} = require('../../mvnw');
+const path = require('path');
+
+/**
+ * Command to transpile XMIR files into target language.
+ * @param {Object} opts - All options
+ * @return {Promise} of transpile task
+ */
+module.exports = function(opts) {
+  const sources = path.resolve(opts.target, 'generated-sources');
+  return mvnw(['eo:transpile'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
+    console.info('Java sources generated in %s', rel(sources));
+    return r;
+  });
+};

--- a/src/commands/js/compile.js
+++ b/src/commands/js/compile.js
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * Command to compile target language into binaries.
+ * @param {Object} opts - All options
+ * @return {Promise} of compile task
+ */
+module.exports = function(opts) {
+  return new Promise((resolve, reject) => {
+    console.info('Compile step is skipped for JavaScript');
+    resolve(opts);
+  });
+};

--- a/src/commands/js/dataize.js
+++ b/src/commands/js/dataize.js
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const eo2jsw = require('../../eo2jsw');
+
+/**
+ * Runs the single executable binary.
+ * @param {String} obj - Name of object to dataize
+ * @param {Array} args - Arguments
+ * @param {Object} opts - All options
+ * @return {Promise} of executed command
+ */
+module.exports = function(obj, args, opts) {
+  return eo2jsw(
+    ['dataize', obj, ...args.filter((arg) => !arg.startsWith('-'))].join(' '),
+    {...opts, alone: true, project: 'project'}
+  );
+};

--- a/src/commands/js/link.js
+++ b/src/commands/js/link.js
@@ -23,18 +23,19 @@
  */
 
 const rel = require('relative');
-const {mvnw, flags} = require('../mvnw');
 const path = require('path');
+const eo2jsw = require('../../eo2jsw');
+const {program} = require('commander');
 
 /**
- * Command to transpile XMIR files into target language.
- * @param {Hash} opts - All options
- * @return {Promise} of transpile task
+ * Command to create and build NPM project.
+ * @param {Object} opts - All options
+ * @return {Promise} of link task
  */
 module.exports = function(opts) {
-  const sources = path.resolve(opts.target, 'generated-sources');
-  return mvnw(['eo:transpile'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
-    console.info('Java sources generated in %s', rel(sources));
+  const tests = program.args[0] === 'test' || !!opts.tests;
+  return eo2jsw('link', {...opts, alone: true, project: 'project', tests}).then((r) => {
+    console.info(`NPM project generated in ${rel(path.resolve(opts.target, 'project'))}`);
     return r;
   });
 };

--- a/src/commands/js/test.js
+++ b/src/commands/js/test.js
@@ -1,0 +1,34 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2024 Objectionary.com
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+const eo2jsw = require('../../eo2jsw');
+
+/**
+ * Command to run all available unit tests.
+ * @param {Object} opts - All options
+ * @return {Promise} of compile task
+ */
+module.exports = function(opts) {
+  return eo2jsw('test', {...opts, alone: true, project: 'project'});
+};

--- a/src/commands/js/transpile.js
+++ b/src/commands/js/transpile.js
@@ -23,18 +23,17 @@
  */
 
 const rel = require('relative');
-const {mvnw, flags} = require('../mvnw');
+const eo2jsw = require('../../eo2jsw');
 const path = require('path');
 
 /**
- * Command to link binaries into a single executable binary.
- * @param {Hash} opts - All options
- * @return {Promise} of link task
+ * Command to transpile XMIR files into target language.
+ * @param {Object} opts - All options
+ * @return {Promise} of transpile task
  */
 module.exports = function(opts) {
-  const jar = path.resolve(opts.target, 'eoc.jar');
-  return mvnw(['jar:jar'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
-    console.info('Executable JAR created at %s', rel(jar));
+  return eo2jsw('transpile', {...opts, alone: true, project: 'project'}).then((r) => {
+    console.info(`JS sources are generated in ${rel(path.resolve(opts.target, 'project'))}`);
     return r;
   });
 };

--- a/src/eo2jsw.js
+++ b/src/eo2jsw.js
@@ -1,0 +1,43 @@
+const path = require('path');
+const {execSync} = require('child_process');
+
+/**
+ * Convert eoc arguments to appropriate eo2js flags
+ * @param {Object} args - eoc arguments
+ * @param {String} lib - Path to eo2js lib
+ * @return {Array.<String>} - Flags for eo2js
+ */
+const flags = function(args, lib) {
+  return [
+    '--target', args.target,
+    '--project', args.project || 'project',
+    '--foreign eo-foreign.json',
+    '--resources', path.resolve(lib, 'resources'),
+    args.alone ? '--alone' : '',
+    args.tests ? '--tests' : ''
+  ];
+};
+
+/**
+ * Wrapper for eo2js.
+ * @param {String} command - Command to execute
+ * @param {Object} args - Command arguments
+ * @return {Promise<Array.<String>>}
+ */
+const eo2jsw = function(command, args) {
+  const lib = path.resolve(__dirname, '../node_modules/eo2js/src');
+  const bin = path.resolve(lib, 'eo2js.js');
+  return new Promise((resolve, reject) => {
+    execSync(
+      `node ${bin} ${command} ${flags(args, lib).filter((flag) => flag !== '').join(' ')}`,
+      {
+        timeout: 1200000,
+        windowsHide: true,
+        stdio: 'inherit'
+      }
+    );
+    resolve(args);
+  });
+};
+
+module.exports = eo2jsw;

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -46,7 +46,7 @@ let beginning;
 
 /**
  * Prepare options for Maven.
- * @param {Hash} opts - Opts provided to the "eoc"
+ * @param {Object} opts - Opts provided to the "eoc"
  * @return {Array} of Maven options
  */
 module.exports.flags = function(opts) {
@@ -72,9 +72,9 @@ module.exports.flags = function(opts) {
 
 /**
  * Run mvnw with provided commands.
- * @param {Hash} args - All arguments to pass to it
- * @param {String} tgt - Path to the target directory
- * @param {Boolean} batch - Is it batch mode (TRUE) or interactive (FALSE)?
+ * @param {Array.<String>} args - All arguments to pass to it
+ * @param {String} [tgt] - Path to the target directory
+ * @param {Boolean} [batch] - Is it batch mode (TRUE) or interactive (FALSE)?
  * @return {Promise} of maven execution task
  */
 module.exports.mvnw = function(args, tgt, batch) {
@@ -131,8 +131,6 @@ module.exports.mvnw = function(args, tgt, batch) {
 
 /**
  * Starts mvnw execution status detection.
- * @param {String} stage - A maven stage like assemble, compile, transpile, etc.
- * @param {String} dir - Directory where to check progress - ./.eoc
  */
 function start() {
   running = true;

--- a/test/commands/test_compile.js
+++ b/test/commands/test_compile.js
@@ -67,7 +67,7 @@ describe('compile', function() {
         '',
         '# This is a sample object',
         '[] > simple-test-compile',
-        '  TRUE > @',
+        '  true > @',
       ].join('\n')
     );
     const stdout = runSync([
@@ -103,6 +103,15 @@ describe('compile', function() {
     ]);
     assert(stdout.includes(`The directory ${rel(path.resolve(home, 'target'))} deleted`), stdout);
     done();
+  });
+
+  it('Skips compilation for JavaScript', function() {
+    const stdout = runSync([
+      'compile',
+      '--alone',
+      '--language=JavaScript'
+    ]);
+    assert.ok(stdout.includes('skipped for JavaScript'));
   });
 });
 

--- a/test/commands/test_dataize.js
+++ b/test/commands/test_dataize.js
@@ -28,18 +28,34 @@ const assert = require('assert');
 const path = require('path');
 const {runSync, parserVersion, homeTag} = require('../helpers');
 
-const versions = new Map([
-  [parserVersion, homeTag],
-  // They don't work, but they should:
-  // Let's continue after this bug is fixed: https://github.com/objectionary/eo/issues/3093
-  // ['0.35.2', '130afdd1456a0cbafd52aee8d7bc612e1faac547'],
-  // ['0.35.1', '130afdd1456a0cbafd52aee8d7bc612e1faac547'],
-  // ['0.34.1', '1d605bd872f27494551e9dd2341b9413d0d96d89'],
-]);
-versions.forEach(function(tag, version) {
-  describe('dataize', function() {
-    it('dataizes with ' + version, function(done) {
-      const home = path.resolve('temp/test-dataize/' + version + '/simple');
+// They don't work, but they should:
+// Let's continue after this bug is fixed: https://github.com/objectionary/eo/issues/3093
+// ['Java', '0.35.2', '130afdd1456a0cbafd52aee8d7bc612e1faac547'],
+// ['Java', '0.35.1', '130afdd1456a0cbafd52aee8d7bc612e1faac547'],
+// ['Java', '0.34.1', '1d605bd872f27494551e9dd2341b9413d0d96d89'],
+const options = [
+  {
+    lang: 'Java',
+    version: parserVersion,
+    tag: homeTag
+  },
+  {
+    lang: 'Java',
+    version: '0.36.0',
+    tag: '0.36.0'
+  },
+  {
+    lang: 'JavaScript',
+    version: parserVersion,
+    tag: homeTag
+  },
+];
+
+describe('dataize', function() {
+  options.forEach(({lang, version, tag}) => {
+    it(`dataizes: lang ${lang}, version ${version}, tag ${tag}`, function(done) {
+      this.timeout(0);
+      const home = path.resolve(`temp/test-dataize/${version}/${lang}`);
       fs.rmSync(home, {recursive: true, force: true});
       fs.mkdirSync(path.resolve(home, 'src/foo/bar'), {recursive: true});
       fs.writeFileSync(
@@ -62,12 +78,14 @@ versions.forEach(function(tag, version) {
         '--home-tag=' + tag,
         '-s', path.resolve(home, 'src'),
         '-t', path.resolve(home, 'target'),
+        '--language=' + lang
       ]);
       assert(stdout.includes('Hello, world!'), stdout);
       assert(stdout.includes(`The directory ${rel(path.resolve(home, 'target'))} deleted`), stdout);
-      assert(!fs.existsSync(path.resolve('../../mvnw/target')));
+      if (lang === 'Java') {
+        assert(!fs.existsSync(path.resolve('../../mvnw/target')));
+      }
       done();
     });
   });
 });
-

--- a/test/commands/test_link.js
+++ b/test/commands/test_link.js
@@ -28,8 +28,13 @@ const path = require('path');
 const {runSync, assertFilesExist, parserVersion, homeTag} = require('../helpers');
 
 describe('link', function() {
-  it('compiles a simple .EO program into an executable .JAR', function(done) {
-    const home = path.resolve('temp/test-link/simple');
+  /**
+   * Run 'link' command
+   * @param {String} home - Home directory
+   * @param {String} lang - Platform language
+   * @return {String} - Stdout
+   */
+  const link = function(home, lang = 'Java') {
     fs.rmSync(home, {recursive: true, force: true});
     fs.mkdirSync(path.resolve(home, 'src/foo/bar'), {recursive: true});
     fs.writeFileSync(
@@ -43,14 +48,20 @@ describe('link', function() {
         '  stdout "Hello, world!" > @',
       ].join('\n')
     );
-    const stdout = runSync([
+    return runSync([
       'link',
       '--verbose',
       '--parser=' + parserVersion,
       '--home-tag=' + homeTag,
       '-s', path.resolve(home, 'src'),
       '-t', path.resolve(home, 'target'),
+      '--language=' + lang,
     ]);
+  };
+  it('compiles a simple .EO program into an executable .JAR', function(done) {
+    this.timeout(0);
+    const home = path.resolve('temp/test-link/java');
+    const stdout = link(home, 'Java');
     assertFilesExist(
       stdout, home,
       [
@@ -63,6 +74,22 @@ describe('link', function() {
       ]
     );
     assert(!fs.existsSync(path.resolve('../../mvnw/target')));
+    done();
+  });
+
+  it('creates and builds NPM project', function(done) {
+    this.timeout(0);
+    const home = path.resolve('temp/test-link/js');
+    const stdout = link(home, 'JavaScript');
+    assertFilesExist(
+      stdout, home,
+      [
+        'target/project/foo/bar/link.js',
+        'target/project/org/eolang/bytes.js',
+        'target/project/node_modules/eo2js-runtime/src/objects/org/eolang/error.js',
+        'target/project/node_modules/eo2js-runtime/src/runtime/phi.js',
+      ]
+    );
     done();
   });
 });

--- a/test/commands/test_test.js
+++ b/test/commands/test_test.js
@@ -25,16 +25,23 @@
 const fs = require('fs');
 const path = require('path');
 const {runSync, assertFilesExist, parserVersion, homeTag} = require('../helpers');
+const assert = require('assert');
 
 describe('test', function() {
-  it('executes a single unit test', function(done) {
-    const home = path.resolve('temp/test-test/simple');
+  /**
+   * Run test command.
+   * @param {String} home - Home directory
+   * @param {String} lang - Target language
+   * @return {String} - Stdout
+   */
+  const test = function(home, lang = 'Java') {
     fs.rmSync(home, {recursive: true, force: true});
     fs.mkdirSync(path.resolve(home, 'src'), {recursive: true});
     fs.writeFileSync(
       path.resolve(home, 'src/simple-test.eo'),
       [
-        '+junit',
+        '+tests',
+        '+any',
         '',
         '# sample',
         '[] > simple-comparison-works',
@@ -43,20 +50,34 @@ describe('test', function() {
         '    5',
       ].join('\n')
     );
-    const stdout = runSync([
+    return runSync([
       'test',
       '--verbose',
       '--parser=' + parserVersion,
       '--home-tag=' + homeTag,
       '-s', path.resolve(home, 'src'),
       '-t', path.resolve(home, 'target'),
+      '--language=' + lang
     ]);
+  };
+  it('executes a single Java unit test', function(done) {
+    const home = path.resolve('temp/test-test/java');
+    const stdout = test(home, 'Java');
     assertFilesExist(
       stdout, home,
       [
         'target/generated-sources/EOsimple_comparison_worksTest.java',
         'target/classes/EOsimple_comparison_worksTest.class',
       ]
+    );
+    done();
+  });
+  it('executes a single JavaScript unit test', function(done) {
+    const home = path.resolve('temp/test-test/javascript');
+    const stdout = test(home, 'JavaScript');
+    assert.ok(stdout.includes('1 passing'));
+    assertFilesExist(
+      stdout, home, ['target/project/simple-test.test.js',]
     );
     done();
   });

--- a/test/commands/test_transpile.js
+++ b/test/commands/test_transpile.js
@@ -27,22 +27,47 @@ const path = require('path');
 const {runSync, assertFilesExist, parserVersion, homeTag} = require('../helpers');
 
 describe('transpile', function() {
-  it('transpiles a simple .EO program', function(done) {
-    const home = path.resolve('temp/test-transpile/transpile');
+  const transpile = function(home, lang) {
     fs.rmSync(home, {recursive: true, force: true});
     fs.mkdirSync(path.resolve(home, 'src'), {recursive: true});
-    fs.writeFileSync(path.resolve(home, 'src/transpile.eo'), '# sample\n[] > transpile\n');
-    const stdout = runSync([
+    fs.writeFileSync(
+      path.resolve(home, 'src/transpile.eo'),
+      [
+        '# Sample.',
+        '[] > transpile'
+      ].join('\n')
+    );
+    const transpiled = path.resolve(home, 'target/8-transpile');
+    if (fs.existsSync(transpiled)) {
+      fs.rmSync(transpiled, {recursive: true, force: true});
+    }
+    return runSync([
       'transpile',
       '--verbose',
       '--parser=' + parserVersion,
       '--home-tag=' + homeTag,
       '-s', path.resolve(home, 'src'),
       '-t', path.resolve(home, 'target'),
+      '--language=' + lang,
     ]);
+  };
+  it('transpiles a simple .EO program to Java', function(done) {
+    this.timeout(0);
+    const home = path.resolve(`temp/test-transpile/java`);
+    const stdout = transpile(home, 'Java');
     assertFilesExist(
       stdout, home,
       ['target/generated-sources/EOtranspile.java']
+    );
+    done();
+  });
+  it('transpiles a simple .EO program to JavaScript', function(done) {
+    this.timeout(0);
+    const home = path.resolve(`temp/test-transpile/js`);
+    const stdout = transpile(home, 'JavaScript');
+    assertFilesExist(
+      stdout, home,
+      ['target/project/transpile.js']
     );
     done();
   });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -25,8 +25,8 @@
 // When you upgrade them, don't forget to place old values to the
 // "test_dataize.js" table of versions, in order to make sure we
 // do test dataization with all possible old versions.
-module.exports.parserVersion = '0.36.0';
-module.exports.homeTag = '0.36.0';
+module.exports.parserVersion = '0.38.0';
+module.exports.homeTag = '0.38.0';
 
 /**
  * Helper to run EOC command line tool.


### PR DESCRIPTION
Closes: #288

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds `eo2js` dependency, updates object types, and refactors Java commands. 

### Detailed summary
- Added `eo2js` dependency
- Updated object types from `Hash` to `Object`
- Refactored Java command paths
- Modified test commands for Java and JavaScript
- Skipped compile step for JavaScript
- Updated `eo2jsw` function for `eo2js` execution

> The following files were skipped due to too many changes: `test/commands/test_link.js`, `src/commands/js/dataize.js`, `.github/workflows/itest.yml`, `src/commands/js/transpile.js`, `src/commands/js/link.js`, `test/commands/test_dataize.js`, `package-lock.json`, `src/eoc.js`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->