### PR TITLE
fix(#293): added directories options for `phi` and `unphi`

### DIFF
--- a/src/commands/phi.js
+++ b/src/commands/phi.js
@@ -29,15 +29,15 @@ const {mvnw, flags} = require('../mvnw');
 
 /**
  * Command to convert .XMIR files into .PHI files.
- * @param {Hash} opts - All options
+ * @param {Object} opts - All options
  * @return {Promise} of assemble task
  */
 module.exports = function(opts) {
   gte('EO parser', opts.parser, '0.35.2');
   const target = path.resolve(opts.target);
-  const input = path.resolve(opts.target, '2-optimize');
+  const input = path.resolve(opts.target, opts.phiInput);
   console.debug('Reading .XMIR files from %s', rel(input));
-  const output = path.resolve(opts.target, 'phi');
+  const output = path.resolve(opts.target, opts.phiOutput);
   console.debug('Writing .PHI files to %s', rel(output));
   return mvnw(
     ['eo:xmir-to-phi']

--- a/src/commands/print.js
+++ b/src/commands/print.js
@@ -28,13 +28,13 @@ const {mvnw, flags} = require('../mvnw');
 
 /**
  * Command to convert .XMIR files into .EO files.
- * @param {Hash} opts - All options
+ * @param {Object} opts - All options
  * @return {Promise} of assemble task
  */
 module.exports = function(opts) {
-  const input = path.resolve(opts.target, '2-optimize');
+  const input = path.resolve(opts.target, opts.printInput);
   console.debug('Reading from %s', rel(input));
-  const output = path.resolve(opts.target, 'print');
+  const output = path.resolve(opts.target, opts.printOutput);
   console.debug('Writing into %s', rel(output));
   return mvnw(
     ['eo:print']

--- a/src/commands/unphi.js
+++ b/src/commands/unphi.js
@@ -29,14 +29,14 @@ const {gte} = require('../demand');
 
 /**
  * Command to convert .PHI files into .XMIR files.
- * @param {Hash} opts - All options
+ * @param {Object} opts - All options
  * @return {Promise} of assemble task
  */
 module.exports = function(opts) {
   gte('EO parser', opts.parser, '0.35.2');
-  const input = path.resolve(opts.target, 'phi');
+  const input = path.resolve(opts.target, opts.unphiInput);
   console.debug('Reading .PHI files from %s', rel(input));
-  const output = path.resolve(opts.target, 'unphi');
+  const output = path.resolve(opts.target, opts.unphiOutput);
   console.debug('Writing .XMIR files to %s', rel(output));
   return mvnw(
     ['eo:phi-to-xmir']

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -179,8 +179,16 @@ program.command('sodg')
 
 program.command('phi')
   .description('Generate PHI files from XMIR')
-  .option('--phi-input <dir>', 'Directory where XMIR files for translation to PHI are taken (relative to --target)', '2-optimize')
-  .option('--phi-output <dir>', 'Directory where translated PHI files are stored (relative to --target)', 'phi')
+  .option(
+    '--phi-input <dir>',
+    'Directory where XMIR files for translation to PHI are taken (relative to --target)',
+    '2-optimize'
+  )
+  .option(
+    '--phi-output <dir>',
+    'Directory where translated PHI files are stored (relative to --target)',
+    'phi'
+  )
   .action((str, opts) => {
     clear(str);
     if (program.opts().alone == undefined) {
@@ -194,8 +202,16 @@ program.command('phi')
 
 program.command('unphi')
   .option('--tests', 'Add "+tests" meta to result XMIR files')
-  .option('--unphi-input <dir>', 'Directory where PHI files for translation to XMIR are taken (relative to --target)', 'phi')
-  .option('--unphi-output <dir>', 'Directory where translated XMIR files are stored (relative to --target)', 'unphi')
+  .option(
+    '--unphi-input <dir>',
+    'Directory where PHI files for translation to XMIR are taken (relative to --target)',
+    'phi'
+  )
+  .option(
+    '--unphi-output <dir>',
+    'Directory where translated XMIR files are stored (relative to --target)',
+    'unphi'
+  )
   .description('Generate XMIR files from PHI files')
   .action((str, opts) => {
     clear(str);

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -220,9 +220,19 @@ program.command('unphi')
 
 program.command('print')
   .description('Generate EO files from XMIR files')
+  .option(
+    '--print-input',
+    'Directory where XMIR files for translation to EO are taken (relative to --target)',
+    '2-optimize'
+  )
+  .option(
+    '--print-output',
+    'Directory where translated EO files are stored (relative to --target)',
+    'print'
+  )
   .action((str, opts) => {
     clear(str);
-    print(program.opts());
+    print({...program.opts(), ...str});
   });
 
 program.command('verify')

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -221,12 +221,12 @@ program.command('unphi')
 program.command('print')
   .description('Generate EO files from XMIR files')
   .option(
-    '--print-input',
+    '--print-input <dir>',
     'Directory where XMIR files for translation to EO are taken (relative to --target)',
     '2-optimize'
   )
   .option(
-    '--print-output',
+    '--print-output <dir>',
     'Directory where translated EO files are stored (relative to --target)',
     'print'
   )

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -179,12 +179,14 @@ program.command('sodg')
 
 program.command('phi')
   .description('Generate PHI files from XMIR')
+  .option('--phi-input <dir>', 'Directory where XMIR files for translation to PHI are taken (relative to --target)', '2-optimize')
+  .option('--phi-output <dir>', 'Directory where translated PHI files are stored (relative to --target)', 'phi')
   .action((str, opts) => {
     clear(str);
     if (program.opts().alone == undefined) {
       register(program.opts())
         .then((r) => assemble(program.opts()))
-        .then((r) => phi(program.opts()));
+        .then((r) => phi({...program.opts(), ...str}));
     } else {
       phi(program.opts());
     }
@@ -192,6 +194,8 @@ program.command('phi')
 
 program.command('unphi')
   .option('--tests', 'Add "+tests" meta to result XMIR files')
+  .option('--unphi-input <dir>', 'Directory where PHI files for translation to XMIR are taken (relative to --target)', 'phi')
+  .option('--unphi-output <dir>', 'Directory where translated XMIR files are stored (relative to --target)', 'unphi')
   .description('Generate XMIR files from PHI files')
   .action((str, opts) => {
     clear(str);

--- a/test/commands/test_phi.js
+++ b/test/commands/test_phi.js
@@ -38,6 +38,8 @@ describe('phi', function() {
       '--track-optimization-steps',
       '--parser=' + parserVersion,
       '--home-tag=' + homeTag,
+      '--phi-input=2-optimize',
+      '--phi-output=output',
       '-s', path.resolve(home, 'src'),
       '-t', path.resolve(home, 'target'),
     ]);
@@ -45,7 +47,7 @@ describe('phi', function() {
       stdout, home,
       [
         'target/2-optimize/phi.xmir',
-        'target/phi/phi.phi',
+        'target/output/phi.phi',
       ]
     );
     done();

--- a/test/commands/test_print.js
+++ b/test/commands/test_print.js
@@ -30,9 +30,9 @@ describe('print', function() {
   it('converts XMIR files to EO files', function(done) {
     const home = path.resolve('temp/test-print/simple');
     fs.rmSync(home, {recursive: true, force: true});
-    fs.mkdirSync(path.resolve(home, 'target/2-optimize'), {recursive: true});
+    fs.mkdirSync(path.resolve(home, 'target/input'), {recursive: true});
     fs.writeFileSync(
-      path.resolve(home, 'target/2-optimize/app.xmir'),
+      path.resolve(home, 'target/input/app.xmir'),
       [
         '<program ms="0" name="xx" time="2024-01-01T01:01:01"',
         'version="0.0.0" dob="2024-01-01T01:01:01" revision="0">',
@@ -47,12 +47,14 @@ describe('print', function() {
       '--track-optimization-steps',
       '--parser=' + parserVersion,
       '--home-tag=' + homeTag,
+      '--print-input=input',
+      '--print-output=output',
       '-t', path.resolve(home, 'target'),
     ]);
     assertFilesExist(
       stdout, home,
       [
-        'target/print/app.eo',
+        'target/output/app.eo',
       ]
     );
     done();

--- a/test/commands/test_unphi.js
+++ b/test/commands/test_unphi.js
@@ -31,8 +31,8 @@ describe('unphi', function() {
   it('converts PHI files to XMIR files', function(done) {
     const home = path.resolve('temp/test-unphi/simple');
     fs.rmSync(home, {recursive: true, force: true});
-    fs.mkdirSync(path.resolve(home, 'target/phi'), {recursive: true});
-    fs.writeFileSync(path.resolve(home, 'target/phi/app.phi'), '{ ⟦ app ↦ ⟦ ⟧ ⟧ }');
+    fs.mkdirSync(path.resolve(home, 'target/input'), {recursive: true});
+    fs.writeFileSync(path.resolve(home, 'target/input/app.phi'), '{ ⟦ app ↦ ⟦ ⟧ ⟧ }');
     const stdout = runSync([
       'unphi',
       '--verbose',
@@ -40,9 +40,11 @@ describe('unphi', function() {
       '--tests',
       '--parser=' + parserVersion,
       '--home-tag=' + homeTag,
+      '--unphi-input=input',
+      '--unphi-output=output',
       '-t', path.resolve(home, 'target'),
     ]);
-    const unphied = 'target/unphi/app.xmir';
+    const unphied = 'target/output/app.xmir';
     assertFilesExist(
       stdout, home,
       [unphied]


### PR DESCRIPTION
Ref: #293

<!-- start pr-codex -->

---

## PR-Codex overview
This PR updates the CLI commands to support customizable input/output directories for file translation tasks.

### Detailed summary
- Added options for `--phi-input` and `--phi-output` in `phi.js`
- Added options for `--unphi-input` and `--unphi-output` in `unphi.js`
- Added options for `--print-input` and `--print-output` in `print.js`
- Updated test files accordingly
- Updated CLI commands in `eoc.js` to handle new options

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->