### PR TITLE
Feat: Add timing to the main log output (ref #368)

### DIFF
--- a/src/commands/assemble.js
+++ b/src/commands/assemble.js
@@ -33,8 +33,10 @@ const {mvnw, flags} = require('../mvnw');
  */
 module.exports = function(opts) {
   const target = path.resolve(opts.target);
+  const startTime = Date.now();
   return mvnw(['eo:assemble'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
-    console.info('EO program assembled in %s', rel(target));
+    const duration = Date.now() - startTime;
+    console.info('EO program assembled in %s in %dms', rel(target), duration);
     return r;
   });
 };

--- a/src/commands/java/compile.js
+++ b/src/commands/java/compile.js
@@ -33,8 +33,10 @@ const path = require('path');
  */
 module.exports = function(opts) {
   const target = path.resolve(opts.target);
+  const startTime = Date.now();
   return mvnw(['compiler:compile'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
-    console.info('Java .class files compiled into %s', rel(target));
+    const duration = Date.now() - startTime;
+    console.info('Java .class files compiled into %s in %dms', rel(target), duration);
     return r;
   });
 };

--- a/src/commands/java/transpile.js
+++ b/src/commands/java/transpile.js
@@ -33,8 +33,10 @@ const path = require('path');
  */
 module.exports = function(opts) {
   const sources = path.resolve(opts.target, 'generated-sources');
+  const startTime = Date.now();
   return mvnw(['eo:transpile'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
-    console.info('Java sources generated in %s', rel(sources));
+    const duration = Date.now() - startTime;
+    console.info('Java sources generated in %s in %dms', rel(sources), duration);
     return r;
   });
 };

--- a/src/commands/register.js
+++ b/src/commands/register.js
@@ -33,8 +33,10 @@ const path = require('path');
  */
 module.exports = function(opts) {
   const foreign = path.resolve(opts.target, 'eo-foreign.json');
+  const startTime = Date.now();
   return mvnw(['eo:register'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
-    console.info('EO objects registered in %s', rel(foreign));
+    const duration = Date.now() - startTime;
+    console.info('EO objects registered in %s in %dms', rel(foreign), duration);
     return r;
   });
 };

--- a/src/commands/verify.js
+++ b/src/commands/verify.js
@@ -32,8 +32,10 @@ const {mvnw, flags} = require('../mvnw');
  * @return {Promise} of assemble task
  */
 module.exports = function(opts) {
+  const startTime = Date.now();
   return mvnw(['eo:verify'].concat(flags(opts)), opts.target, opts.batch).then((r) => {
-    console.info('EO program verified in %s', rel(path.resolve(opts.target)));
+    const duration = Date.now() - startTime;
+    console.info('EO program verified in %s in %dms', rel(path.resolve(opts.target)), duration);
     return r;
   });
 };


### PR DESCRIPTION
Feature #368 
Add Timing to the main log output 

Description

1. **Start Time Capture**: I introduced a startTime variable to record the current time at the beginning of the function with Date.now().

2. **Execution Duration Calculation**: After the command completes, I added a duration variable to calculate the time taken by subtracting startTime from the current time (Date.now()), which gives the duration in milliseconds.

3. **Enhanced Logging**: I updated the console.info log message to include the duration in milliseconds (%dms). Now, the log shows not only the completion message ("EO program assembled") but also the time it took to execute.

Modified lines: 
1. console.info('EO program assembled in %s in %dms', rel(target), duration); at assemble.js
2. console.info('Java .class files compiled into %s in %dms', rel(target), duration); at compile.js
3. console.info('Java sources generated in %s in %dms', rel(sources), duration); at transpile.js
4. console.info('EO objects registered in %s in %dms', rel(foreign), duration); at register.js
5. console.info('EO program verified in %s in %dms', rel(path.resolve(opts.target)), duration); at verify.js

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds timing measurements to various command functions in the codebase, allowing for better performance tracking by logging the duration of each operation.

### Detailed summary
- Added `startTime` variable to capture the start time for each command function.
- Calculated `duration` by subtracting `startTime` from the current time.
- Updated console log messages to include the duration in milliseconds for:
  - `verify`
  - `assemble`
  - `register`
  - `compile`
  - `transpile`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->