### PR TITLE
fixed clean message bug

### DIFF
--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -33,8 +33,9 @@ const os = require('os');
  */
 module.exports = function(opts) {
   const home = path.resolve(opts.target);
-  fs.rmSync(home, {recursive: true, force: true});
+  
   if (fs.existsSync(home)) {
+    fs.rmSync(home, {recursive: true, force: true});
     console.info('The directory %s deleted', rel(home));
   } else {
     console.info('The directory %s doesn\'t exist, no need to delete', rel(home));


### PR DESCRIPTION
I made a fix for issue #382 by moving the line that deletes the directory

`fs.rmSync(home, {recursive: true, force: true});`

to only execute after checking if it exists. Before it would delete the directory, then check if it exists, and because it was already deleted it would always give the message

`The directory .eoc doesn't exist, no need to delete`

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the logging functionality in the `clean.js` command by providing feedback on the deletion status of a directory.

### Detailed summary
- Added a log message to inform when the directory has been successfully deleted: `console.info('The directory %s deleted', rel(home));`
- Retained the log message for when the directory does not exist: `console.info('The directory %s doesn\'t exist, no need to delete', rel(home));`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->