### PR TITLE
chore(471): Up Node version in CI

### DIFF
--- a/.github/workflows/grunt.yml
+++ b/.github/workflows/grunt.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ windows-2022, ubuntu-24.04, macos-15 ]
         java: [ 17 ]
-        node: [ 16 ]
+        node: [ 18 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: [ ubuntu-24.04, macos-15, windows-2022 ]
         java: [ 22 ]
-        node: [ 16 ]
+        node: [ 18 ]
         # lang: [Java, JavaScript]
         lang: [ Java ]
     runs-on: ${{ matrix.os }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,12 +24,14 @@
         "grunt-contrib-clean": "2.0.1",
         "grunt-eslint": "24.3.0",
         "grunt-mocha-cli": "^4.0.0",
-        "mocha": "10.8.2"
+        "mocha": "10.8.2",
+        "patch-package": "^8.0.0"
       },
       "engines": {
         "node": ">6.0",
         "npm": ">8.0"
       },
+      "hasInstallScript": true,
       "license": "MIT",
       "name": "eolang",
       "os": [
@@ -331,6 +333,13 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
       "version": "1.2.0"
     },
+    "node_modules/@yarnpkg/lockfile": {
+      "dev": true,
+      "integrity": "sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==",
+      "license": "BSD-2-Clause",
+      "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
+      "version": "1.1.0"
+    },
     "node_modules/abbrev": {
       "dev": true,
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
@@ -474,6 +483,16 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "version": "0.4.0"
     },
+    "node_modules/at-least-node": {
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      },
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
+      "version": "1.0.0"
+    },
     "node_modules/axios": {
       "dependencies": {
         "follow-redirects": "^1.15.6",
@@ -544,11 +563,10 @@
     },
     "node_modules/call-bind": {
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.0",
         "es-define-property": "^1.0.0",
-        "es-errors": "^1.3.0",
-        "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.4",
-        "set-function-length": "^1.2.1"
+        "set-function-length": "^1.2.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -556,10 +574,40 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       },
-      "integrity": "sha512-GHTSNSYICQ7scH7sZ+M2rFopRoLh8t2bLSW6BbgrtLsahOIB5iyAVJf9GjWK3cYTDaMj4XdBpM1cA6pIS0Kv2w==",
+      "integrity": "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.7.tgz",
-      "version": "1.0.7"
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.8.tgz",
+      "version": "1.0.8"
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "version": "1.0.2"
+    },
+    "node_modules/call-bound": {
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "version": "1.0.4"
     },
     "node_modules/callsites": {
       "dev": true,
@@ -644,6 +692,22 @@
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "version": "5.1.2"
+    },
+    "node_modules/ci-info": {
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "version": "3.9.0"
     },
     "node_modules/cliui": {
       "dependencies": {
@@ -857,6 +921,20 @@
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
       "version": "3.0.0"
     },
+    "node_modules/dunder-proto": {
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "version": "1.0.1"
+    },
     "node_modules/emoji-regex": {
       "dev": true,
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
@@ -880,16 +958,13 @@
       "version": "0.0.8"
     },
     "node_modules/es-define-property": {
-      "dependencies": {
-        "get-intrinsic": "^1.2.4"
-      },
       "engines": {
         "node": ">= 0.4"
       },
-      "integrity": "sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.0.tgz",
-      "version": "1.0.0"
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/es-errors": {
       "engines": {
@@ -899,6 +974,18 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "version": "1.3.0"
+    },
+    "node_modules/es-object-atoms": {
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "version": "1.1.1"
     },
     "node_modules/escalade": {
       "dev": true,
@@ -1250,6 +1337,16 @@
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "version": "5.0.0"
     },
+    "node_modules/find-yarn-workspace-root": {
+      "dependencies": {
+        "micromatch": "^4.0.2"
+      },
+      "dev": true,
+      "integrity": "sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==",
+      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz",
+      "version": "2.0.0"
+    },
     "node_modules/findup-sync": {
       "dependencies": {
         "detect-file": "^1.0.0",
@@ -1381,6 +1478,22 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.1.tgz",
       "version": "4.0.1"
     },
+    "node_modules/fs-extra": {
+      "dependencies": {
+        "at-least-node": "^1.0.0",
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+      "version": "9.1.0"
+    },
     "node_modules/fs.realpath": {
       "dev": true,
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
@@ -1424,11 +1537,16 @@
     },
     "node_modules/get-intrinsic": {
       "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "has-proto": "^1.0.1",
-        "has-symbols": "^1.0.3",
-        "hasown": "^2.0.0"
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -1436,10 +1554,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       },
-      "integrity": "sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.4.tgz",
-      "version": "1.2.4"
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "version": "1.3.0"
     },
     "node_modules/get-port": {
       "engines": {
@@ -1449,6 +1567,19 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
       "version": "3.2.0"
+    },
+    "node_modules/get-proto": {
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/getobject": {
       "dev": true,
@@ -1553,16 +1684,23 @@
       "version": "14.0.0"
     },
     "node_modules/gopd": {
-      "dependencies": {
-        "get-intrinsic": "^1.1.3"
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       },
-      "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
-      "version": "1.0.1"
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "version": "1.2.0"
+    },
+    "node_modules/graceful-fs": {
+      "dev": true,
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "version": "4.2.11"
     },
     "node_modules/graphemer": {
       "dev": true,
@@ -2157,18 +2295,6 @@
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
       "version": "1.0.2"
     },
-    "node_modules/has-proto": {
-      "engines": {
-        "node": ">= 0.4"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      },
-      "integrity": "sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==",
-      "license": "MIT",
-      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.3.tgz",
-      "version": "1.0.3"
-    },
     "node_modules/has-symbols": {
       "engines": {
         "node": ">= 0.4"
@@ -2176,10 +2302,10 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       },
-      "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
-      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
-      "version": "1.0.3"
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "version": "1.1.0"
     },
     "node_modules/hasown": {
       "dependencies": {
@@ -2374,6 +2500,22 @@
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.15.1.tgz",
       "version": "2.15.1"
     },
+    "node_modules/is-docker": {
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
+      "version": "2.2.1"
+    },
     "node_modules/is-extglob": {
       "dev": true,
       "engines": {
@@ -2499,6 +2641,19 @@
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
       "version": "1.0.2"
     },
+    "node_modules/is-wsl": {
+      "dependencies": {
+        "is-docker": "^2.0.0"
+      },
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
+      "version": "2.2.0"
+    },
     "node_modules/isarray": {
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT",
@@ -2549,12 +2704,62 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "version": "0.4.1"
     },
+    "node_modules/json-stable-stringify": {
+      "dependencies": {
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.3",
+        "isarray": "^2.0.5",
+        "jsonify": "^0.0.1",
+        "object-keys": "^1.1.1"
+      },
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "integrity": "sha512-Lp6HbbBgosLmJbjx0pBLbgvx68FaFU1sdkmBuckmhhJ88kL13OA51CDtR2yJB50eCNMH9wRqtQNNiAqQH4YXnA==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.2.1.tgz",
+      "version": "1.2.1"
+    },
     "node_modules/json-stable-stringify-without-jsonify": {
       "dev": true,
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "version": "1.0.1"
+    },
+    "node_modules/json-stable-stringify/node_modules/isarray": {
+      "dev": true,
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "version": "2.0.5"
+    },
+    "node_modules/jsonfile": {
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "dev": true,
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      },
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "version": "6.1.0"
+    },
+    "node_modules/jsonify": {
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==",
+      "license": "Public Domain",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+      "version": "0.0.1"
     },
     "node_modules/keyv": {
       "dependencies": {
@@ -2575,6 +2780,16 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "version": "6.0.3"
+    },
+    "node_modules/klaw-sync": {
+      "dependencies": {
+        "graceful-fs": "^4.1.11"
+      },
+      "dev": true,
+      "integrity": "sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/klaw-sync/-/klaw-sync-6.0.0.tgz",
+      "version": "6.0.0"
     },
     "node_modules/levn": {
       "dependencies": {
@@ -2695,6 +2910,15 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
       "version": "0.2.2"
+    },
+    "node_modules/math-intrinsics": {
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "version": "1.1.0"
     },
     "node_modules/micromatch": {
       "dependencies": {
@@ -2932,6 +3156,16 @@
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.2.tgz",
       "version": "1.13.2"
     },
+    "node_modules/object-keys": {
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
+      "version": "1.1.1"
+    },
     "node_modules/object.defaults": {
       "dependencies": {
         "array-each": "^1.0.1",
@@ -2984,6 +3218,23 @@
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "version": "1.4.0"
+    },
+    "node_modules/open": {
+      "dependencies": {
+        "is-docker": "^2.0.0",
+        "is-wsl": "^2.1.1"
+      },
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      },
+      "integrity": "sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/open/-/open-7.4.2.tgz",
+      "version": "7.4.2"
     },
     "node_modules/optionator": {
       "dependencies": {
@@ -3109,6 +3360,47 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
       "version": "1.0.0"
+    },
+    "node_modules/patch-package": {
+      "bin": {
+        "patch-package": "index.js"
+      },
+      "dependencies": {
+        "@yarnpkg/lockfile": "^1.1.0",
+        "chalk": "^4.1.2",
+        "ci-info": "^3.7.0",
+        "cross-spawn": "^7.0.3",
+        "find-yarn-workspace-root": "^2.0.0",
+        "fs-extra": "^9.0.0",
+        "json-stable-stringify": "^1.0.2",
+        "klaw-sync": "^6.0.0",
+        "minimist": "^1.2.6",
+        "open": "^7.4.2",
+        "rimraf": "^2.6.3",
+        "semver": "^7.5.3",
+        "slash": "^2.0.0",
+        "tmp": "^0.0.33",
+        "yaml": "^2.2.2"
+      },
+      "dev": true,
+      "engines": {
+        "node": ">=14",
+        "npm": ">5"
+      },
+      "integrity": "sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/patch-package/-/patch-package-8.0.0.tgz",
+      "version": "8.0.0"
+    },
+    "node_modules/patch-package/node_modules/minimist": {
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      },
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "version": "1.2.8"
     },
     "node_modules/path-exists": {
       "dev": true,
@@ -3558,6 +3850,16 @@
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.6.tgz",
       "version": "1.0.6"
     },
+    "node_modules/slash": {
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      },
+      "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+      "version": "2.0.0"
+    },
     "node_modules/sprintf-js": {
       "dev": true,
       "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
@@ -3726,6 +4028,19 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
       "version": "2.5.2"
     },
+    "node_modules/tmp": {
+      "dependencies": {
+        "os-tmpdir": "~1.0.2"
+      },
+      "dev": true,
+      "engines": {
+        "node": ">=0.6.0"
+      },
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "version": "0.0.33"
+    },
     "node_modules/to-regex-range": {
       "dependencies": {
         "is-number": "^7.0.0"
@@ -3794,6 +4109,16 @@
       "license": "MIT",
       "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.6.tgz",
       "version": "3.3.6"
+    },
+    "node_modules/universalify": {
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      },
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "version": "2.0.1"
     },
     "node_modules/uri-js": {
       "dependencies": {
@@ -3900,6 +4225,19 @@
       "license": "ISC",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "version": "5.0.8"
+    },
+    "node_modules/yaml": {
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      },
+      "integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
+      "version": "2.7.0"
     },
     "node_modules/yargs": {
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "grunt-contrib-clean": "2.0.1",
     "grunt-eslint": "24.3.0",
     "grunt-mocha-cli": "^4.0.0",
-    "mocha": "10.8.2"
+    "mocha": "10.8.2",
+    "patch-package": "^8.0.0"
   },
   "engines": {
     "node": ">6.0",
@@ -49,7 +50,8 @@
   ],
   "repository": "objectionary/eoc",
   "scripts": {
-    "test": "mocha --timeout 1200000"
+    "test": "mocha --timeout 1200000",
+    "postinstall": "patch-package"
   },
   "version": "0.0.0"
 }

--- a/patches/grunt-mocha-cli+4.0.0.patch
+++ b/patches/grunt-mocha-cli+4.0.0.patch
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
+# SPDX-License-Identifier: MIT
+diff --git a/node_modules/grunt-mocha-cli/lib/index.js b/node_modules/grunt-mocha-cli/lib/index.js
+index bc0dc26..02afdce 100644
+--- a/node_modules/grunt-mocha-cli/lib/index.js
++++ b/node_modules/grunt-mocha-cli/lib/index.js
+@@ -2,6 +2,7 @@
+ const fs = require('fs')
+ const path = require('path')
+ const grunt = require('grunt')
++const os = require('os')
+ 
+ const BOOL_OPTIONS = [
+   'allow-uncaught',
+@@ -57,6 +58,10 @@ module.exports = function(options) {
+     spawnOptions.cmd = path.dirname(spawnOptions.cmd)
+     spawnOptions.cmd += '/../.bin/mocha'
+ 
++    if (os.platform() === 'win32') {
++      spawnOptions.opts.shell = true
++    }
++
+     if (process.platform === 'win32') {
+       spawnOptions.cmd += '.cmd'
+     }


### PR DESCRIPTION
Node v16 does not receive security updates, while Node v18 does. This pull request changes the Node version used in CI.

One such security patch is https://nodejs.org/en/blog/vulnerability/april-2024-security-releases-2. To fix the issue of newer versions of Node on Windows throwing error `spawn EINVAL` when running grunt, patches suggested [here](https://github.com/mochajs/mocha/issues/5162#issuecomment-2575628439) are applied.

The effect of patch can be seen:
- pre-patch CI run: https://github.com/Dirakon/eoc/actions/runs/14158447695/job/39660710180?pr=3 (`Warning: spawn EINVAL`)
- post-patch CI run: current CI

By adding the patches, this pull request should not only fix the CI for newer Node versions, but also resolve this problem for Windows users: https://github.com/objectionary/eoc/issues/423