### PR TITLE
chore(#517): refresh grunt-mocha-cli patch

### DIFF
--- a/patches/grunt-mocha-cli+7.0.0.patch
+++ b/patches/grunt-mocha-cli+7.0.0.patch
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 diff --git a/node_modules/grunt-mocha-cli/lib/index.js b/node_modules/grunt-mocha-cli/lib/index.js
-index bc0dc26..02afdce 100644
+index 59f7a07..4cc7182 100644
 --- a/node_modules/grunt-mocha-cli/lib/index.js
 +++ b/node_modules/grunt-mocha-cli/lib/index.js
 @@ -2,6 +2,7 @@
@@ -9,13 +9,13 @@ index bc0dc26..02afdce 100644
  const path = require('path')
  const grunt = require('grunt')
 +const os = require('os')
-
+ 
  const BOOL_OPTIONS = [
    'allow-uncaught',
-@@ -57,6 +58,10 @@ module.exports = function(options) {
+@@ -55,6 +56,10 @@ module.exports = function(options) {
      spawnOptions.cmd = path.dirname(spawnOptions.cmd)
      spawnOptions.cmd += '/../.bin/mocha'
-
+ 
 +    if (os.platform() === 'win32') {
 +      spawnOptions.opts.shell = true
 +    }


### PR DESCRIPTION
See #517 for details.

Additionally, a slight modification to eslint job was needed - otherwise I receive error (like seen here: https://github.com/objectionary/eoc/actions/runs/15075278848/job/42381146058 - `TypeError: Key "rules": Key "no-unassigned-vars": Could not find "no-unassigned-vars" in plugin "@".`)