### PR TITLE
add HTTP inspection server with Takes framework

### DIFF
--- a/mvnw/pom.xml
+++ b/mvnw/pom.xml
@@ -110,7 +110,7 @@
           <archive>
             <manifest>
               <addClasspath>true</addClasspath>
-              <mainClass>org.eolang.App</mainClass>
+              <mainClass>org.eolang.Main</mainClass>
             </manifest>
           </archive>
         </configuration>

--- a/mvnw/pom.xml
+++ b/mvnw/pom.xml
@@ -35,10 +35,20 @@
       <version>5.12.2</version>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>org.takes</groupId>
+      <artifactId>takes</artifactId>
+      <version>1.24.6</version>
+    </dependency>
   </dependencies>
   <build>
     <finalName>eoc</finalName>
     <sourceDirectory>${eo.generatedDir}</sourceDirectory>
+    <resources>
+      <resource>
+        <directory>${eo.generatedDir}</directory>
+      </resource>
+    </resources>
     <directory>${eo.targetDir}</directory>
     <outputDirectory>${eo.targetDir}/classes</outputDirectory>
     <testOutputDirectory>${eo.targetDir}/classes</testOutputDirectory>
@@ -100,7 +110,7 @@
           <archive>
             <manifest>
               <addClasspath>true</addClasspath>
-              <mainClass>org.eolang.Main</mainClass>
+              <mainClass>org.eolang.App</mainClass>
             </manifest>
           </archive>
         </configuration>
@@ -126,6 +136,27 @@
               junit.jupiter.execution.parallel.mode.classes.default = concurrent
             </configurationParameters>
           </properties>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>3.1.0</version>
+        <executions>
+          <execution>
+            <id>start-server</id>
+            <phase>pre-integration-test</phase>
+            <goals>
+              <goal>java</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <mainClass>org.eolang.Inspect</mainClass>
+          <cleanupDaemonThreads>false</cleanupDaemonThreads>
+          <arguments>
+            <argument>--port=${port}</argument>
+          </arguments>
         </configuration>
       </plugin>
     </plugins>

--- a/mvnw/src/main/java/org/eolang/Inspect.java
+++ b/mvnw/src/main/java/org/eolang/Inspect.java
@@ -1,0 +1,31 @@
+package org.eolang;
+
+import org.takes.Request;
+import org.takes.Response;
+import org.takes.Take;
+import org.takes.http.Exit;
+import org.takes.http.FtBasic;
+import org.takes.facets.fork.FkRegex;
+import org.takes.facets.fork.TkFork;
+import org.takes.rq.RqPrint;
+import org.takes.rs.RsText;
+
+import java.io.IOException;
+
+public final class Inspect {
+    public static void main(final String... args) throws Exception {
+        new FtBasic(
+                new TkFork(
+                        new FkRegex("/echo", new Take() {
+                            @Override
+                            public Response act(Request req) throws IOException {
+                                String body = new RqPrint(req).printBody();
+                                return new RsText(body);
+                            }
+                        }),
+                        new FkRegex("/", new RsText("Server is running. Use /echo endpoint"))
+                ),
+                8080
+        ).start(Exit.NEVER);
+    }
+}

--- a/src/commands/inspect.js
+++ b/src/commands/inspect.js
@@ -1,0 +1,116 @@
+const { spawn } = require('child_process');
+const path = require('path');
+const os = require('os');
+const readline = require('readline');
+const fetch = require('node-fetch');
+
+module.exports = function(opts) {
+  return new Promise((resolve, reject) => {
+    const mvnDir = path.join(process.cwd(), 'mvnw');
+
+    console.info('Building EO inspect server with Maven...');
+
+    const mvnCmd = os.platform() === 'win32' ? 'mvn.cmd' : 'mvn';
+
+    const mvn = spawn(mvnCmd, [
+      'clean',
+      'package',
+      'dependency:copy-dependencies',
+      '-Deo.targetDir=target',
+      '-DoutputDirectory=target/lib',
+    ], {
+      cwd: mvnDir,
+      stdio: 'inherit',
+    });
+
+    mvn.on('close', (code) => {
+      if (code !== 0) {
+        reject(new Error('Maven build failed'));
+        return;
+      }
+
+      const isWindows = os.platform() === 'win32';
+      const sep = isWindows ? ';' : ':';
+      const classpath = [
+        path.join(mvnDir, 'target', 'classes'),
+        path.join(mvnDir, 'target', 'lib', '*'),
+      ].join(sep);
+
+      console.info('Starting EO inspect server...');
+      const server = spawn('java', ['-cp', classpath, 'org.eolang.Inspect'], {
+        cwd: mvnDir,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+
+      server.stdout.setEncoding('utf8');
+      server.stderr.setEncoding('utf8');
+
+      server.stdout.on('data', (data) => {
+        console.log(`[SERVER] ${data}`);
+      });
+
+      server.stderr.on('data', (data) => {
+        console.error(`[SERVER ERROR] ${data}`);
+      });
+
+      setTimeout(() => {
+        console.info('EO inspect server started.');
+
+        const rl = readline.createInterface({
+          input: process.stdin,
+          output: process.stdout,
+          terminal: true
+        });
+
+        const ask = (query) => new Promise(res => rl.question(query, res));
+
+        (async () => {
+          try {
+            while (true) {
+              const input = await ask('Enter text (or type "exit" to quit): ');
+              if (input.trim().toLowerCase() === 'exit') {
+                console.info('Exiting...');
+                server.kill();
+                rl.close();
+                resolve();
+                break;
+              }
+
+              console.log('Sending request with body:', input);
+
+              try {
+                const response = await fetch('http://localhost:8080/echo', {
+                  method: 'POST',
+                  headers: {
+                    'Content-Type': 'text/plain; charset=utf-8'
+                  },
+                  body: input,
+                });
+
+                if (!response.ok) {
+                  throw new Error(`HTTP error! status: ${response.status}`);
+                }
+
+                const reply = await response.text();
+                console.log('Server responded:', reply);
+              } catch (err) {
+                console.error('Request failed:', err.message);
+              }
+            }
+          } catch (e) {
+            rl.close();
+            server.kill();
+            reject(e);
+          }
+        })();
+
+      }, 2000);
+
+      server.on('close', (code) => {
+        console.info(`Server stopped with code ${code}`);
+      });
+    });
+
+    mvn.on('error', (err) => reject(err));
+  });
+};

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -32,6 +32,7 @@ const {program} = require('commander'),
     lint: require('./commands/lint'),
     docs: require('./commands/docs'),
     generate_comments: require('./commands/generate_comments'),
+    inspect: require('./commands/inspect'),
     jeo_disassemble: require('./commands/jeo/disassemble'),
     jeo_assemble: require('./commands/jeo/assemble'),
     latex: require('./commands/latex')
@@ -445,6 +446,12 @@ program.command('fmt')
           printOutput: program.opts().sources,
           ...program.opts()
         }));
+  });
+
+program.command('inspect')
+  .description('Start EO inspect server and send input')
+  .action((str, opts) => {
+    coms().inspect(program.opts());
   });
 
 try {


### PR DESCRIPTION
Add inspect command which run web server with Takes framework and allow to send text from console to server and displays response from server in console (just testing server running, without real inspecting functionality)

Add Takes dependency in pom.xml

@yegor256 Please can you take a look and answer am I correct starting implement server part for inspect command and working with maven in proper way? 

I intentionally didn't include tests in this PR as I wanted to first align on the architectural approach. I'm ready to add tests in the next pull request after getting your approval on the current implementation."