### PR TITLE
fix: warn does not throw now

### DIFF
--- a/src/tinted-console.js
+++ b/src/tinted-console.js
@@ -18,7 +18,7 @@ const util = require('node:util'),
     'trace': 'gray',
     'debug': 'gray',
     'info': 'white',
-    'warn': 'orange',
+    'warn': 'yellow',
     'error': 'red',
   };
 

--- a/test/test_tinted_console.js
+++ b/test/test_tinted_console.js
@@ -1,0 +1,13 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+
+describe('tinted-console', () => {
+  it('allows console.warn without errors', () => {
+    require('../src/tinted-console');
+    assert.doesNotThrow(() => console.warn('ok'));
+  });
+});


### PR DESCRIPTION
The tinted-console helper maps console.warn() messages to a non-existent “orange” color, which causes a runtime error whenever console.warn() is used.

I replaced the unsupported “orange” color with “yellow” in the console tinting logic to avoid runtime errors on console.warn()