### PR TITLE
Add timestamps for maven logs (#94)

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -62,15 +62,21 @@ module.exports.mvnw = function(args, tgt, batch) {
   return new Promise((resolve, reject) => {
     target = tgt;
     phase = args[0];
+    const jvmLogArgs = [
+      '-Dorg.slf4j.simpleLogger.showDateTime=true',
+      '-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss'
+    ];
     const home = path.resolve(__dirname, '../mvnw'),
       bin = path.resolve(home, 'mvnw') + (process.platform === 'win32' ? '.cmd' : ''),
-      params = args.filter((t) => t !== '').concat([
-        '--batch-mode',
-        '--color=never',
-        '--update-snapshots',
-        '--fail-fast',
-        '--strict-checksums',
-      ]),
+      params = jvmLogArgs.concat(
+        args.filter((t) => t !== '').concat([
+          '--batch-mode',
+          '--color=never',
+          '--update-snapshots',
+          '--fail-fast',
+          '--strict-checksums',
+        ])
+      ),
       cmd = `${bin  } ${  params.join(' ')}`;
     console.debug('+ %s', cmd);
     const result = spawn(

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -4,6 +4,7 @@
  */
 
 const {mvnw, flags} = require('../src/mvnw');
+const { spawn } = require('child_process');
 const assert = require('assert');
 
 describe('mvnw', () => {
@@ -22,6 +23,31 @@ describe('mvnw', () => {
     mvnw(['--version', '--quiet', ...flags(opts)]).then((args) => {
       assert.ok(args.includes('-Deo.tag=homeTag'));
       assert.ok(args.includes('-Deo.version=parser'));
+      done();
+    });
+  });
+
+  it('includes timestamps in Maven logs', (done) => {
+    const mvnwPath = require('path').resolve(__dirname, '../mvnw/mvnw');
+    const args = [
+      '-Dorg.slf4j.simpleLogger.showDateTime=true',
+      '-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss',
+      'validate',
+      '--quiet'
+    ];
+    const proc = spawn(mvnwPath, args);
+
+    let output = '';
+    proc.stdout.on('data', (data) => {
+      output += data.toString();
+    });
+    proc.stderr.on('data', (data) => {
+      output += data.toString();
+    });
+    proc.on('close', (code) => {
+      const lines = output.split('\n');
+      const hasTimestamp = lines.some(line => /\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}/.test(line));
+      assert.ok(hasTimestamp, 'Maven output should include timestamps');
       done();
     });
   });


### PR DESCRIPTION
Adding timestamps makes code more understandable by establishing a sequence of events and utilizing an industry standard.