### PR TITLE
feat: add timestamps to maven build logs

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -69,6 +69,8 @@ module.exports.mvnw = function (args, tgt, batch) {
       bin = 'mvn';
     }
     const params = args.filter((t) => t !== '').concat([
+      '-Dorg.slf4j.simpleLogger.showDateTime=true',
+      '-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss',
       '--batch-mode',
       '--color=never',
       '--update-snapshots',


### PR DESCRIPTION
This PR adds timestamp formatting to Maven build logs to make it easier to track build performance and debug timing issues.

## Changes
- Added `-Dorg.slf4j.simpleLogger.showDateTime=true` to enable timestamp display
- Added `-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss` to set timestamp format

## Example Output
Before:
```
[INFO] Scanning for projects...
[INFO] BUILD SUCCESS
[INFO] Total time:  2.039 s
```

After:
```
2025-10-27 04:40:41 [INFO] Scanning for projects...
2025-10-27 04:40:43 [INFO] BUILD SUCCESS
2025-10-27 04:40:43 [INFO] Total time:  2.039 s
```
<img width="783" height="391" alt="Screenshot 2025-10-27 124118" src="https://github.com/user-attachments/assets/d616fdd0-ae90-4e9b-abb2-914f6db86e66" />

## Testing
- All existing tests pass
- Manually verified timestamp output with `eoc --verbose parse` command

Fixes #94