### PR TITLE
fix(#3): nyc coverage added

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2016-2025 Objectionary.com
+# SPDX-FileCopyrightText: Copyright (c) 2022-2025 Objectionary.com
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
@@ -33,7 +33,7 @@ jobs:
       - name: Run tests with coverage
         run: npm run coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v4
         with:
           file: ./coverage/lcov.info
           flags: unittests

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -33,8 +33,6 @@ jobs:
           distribution: 'zulu'
           java-version: ${{ matrix.java }}
       - run: npm install
-      - name: Run unit tests
-        run: npm test
       - shell: bash
         run: |
           cd itest

--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
   },
   "nyc": {
     "include": [
-      "src/**/*.js",
-      "lib/**/*.js"
+      "src/**/*.js"
     ],
     "exclude": [
       "test/**",


### PR DESCRIPTION
@yegor256, Hi!
This PR covers #3 issue

After runnig the tests I got the following output:

<img width="493" height="216" alt="image" src="https://github.com/user-attachments/assets/c3045a38-026b-47ca-9851-aeaa239371cb" />

Also, these files, ignored by `gitignore`, appear in the project on my end - `/.nyc_output` and `/coverage`.