### PR TITLE
fix(#767): codecov-action action@v5 changes its file to files

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Run tests with coverage
         run: npm run coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./coverage/lcov.info
           flags: unittests


### PR DESCRIPTION
@yegor256 
This PR covers #767 
Since that `codecov-action@v5` changed it's `file` parameter to `files`, it should pass