### PR TITLE
fix(#778): prints Maven own version test uses async/await

### DIFF
--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -9,10 +9,9 @@ const fs = require('fs');
 const path = require('path');
 
 describe('mvnw', () => {
-  it('prints Maven own version', (done) => {
+  it('prints Maven own version', async () => {
     const opts = {batch: true};
-    mvnw(['--version', '--quiet'], null, opts.batch);
-    done();
+    await mvnw(['--version', '--quiet'], null, opts.batch);
   });
   it('sets right flags from options', async () => {
     const opts = {


### PR DESCRIPTION
@yegor256 
This PR covers #778 issue and refactors the test to use `async/await` syntax, so when the code passes the `await` line, the test passes successfully.