### PR TITLE
fix(#13): test path and normal path are separated

### DIFF
--- a/mvnw/pom.xml
+++ b/mvnw/pom.xml
@@ -16,7 +16,7 @@
     <eo.version>undefined</eo.version>
     <heap-size>undefined</heap-size>
     <stack-size>undefined</stack-size>
-    <junit.version>5.10.0</junit.version>
+    <junit.version>6.0.1</junit.version>
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
@yegor256 
Based on #13 issue description, we have a `<profile>` in `pom.xml`. 
Normal build uses default configuration that excludes test files, skips tests, and doesn't include JUnit.
Test build  activates the test profile which includes `**/*-test.eo files`, adds JUnit dependencies and configures Surefire to run tests