### PR TITLE
#435 resolve todo#368

### DIFF
--- a/src/elapsed.js
+++ b/src/elapsed.js
@@ -17,8 +17,6 @@
  *                          is invoked with a `tracked` object as an argument.
  * @return {*} Result of the wrapped callback function. The result of the
  *             `task` callback will be returned unchanged.
- * @todo #368:30min Decide if the `elapsed` utility function is in the right place,
- *  consider relocating it and its test file if needed
  */
 module.exports.elapsed = function elapsed(task) {
   const startTime = Date.now();


### PR DESCRIPTION
So elapsed.js needs to stay in src/ because:
  1. ✅ It's actively used in the assemble command
  2. ✅ There's a plan to use it in the compile command too
  3. ✅ It's a reusable utility that any command can import