### PR TITLE
fix(#854): update test script to include tests in the test/* folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
   "scripts": {
     "coverage": "nyc --reporter=lcov --reporter=text-summary mocha test/**/*.js --timeout 1200000",
     "postinstall": "node scripts/postinstall.js",
-    "test": "mocha test/**/*.js --timeout 1200000"
+    "test": "mocha 'test/**/*.js' --timeout 1200000"
   },
   "version": "0.0.0"
 }


### PR DESCRIPTION
This PR updates the `test` script in `package.json` to ensure Mocha runs tests in the `test/*` folder correctly.

Fixes #854