### PR TITLE
fix(#880): fix bugs in the scripts that generate homebrew formulas with different versions

### DIFF
--- a/.github/homebrew_formula_up.sh
+++ b/.github/homebrew_formula_up.sh
@@ -39,6 +39,9 @@ else
   echo "Copied $ORIG_FORMULA to $FORMULA_FILE_PREV"
 fi
 
+DOTLESS_VERSION="${VERSION//./}"
+sed -i -E "s/^class Eolang /class EolangAT${DOTLESS_VERSION} /" "$FORMULA_FILE_PREV"
+
 TARBALL_URL="https://github.com/${GITHUB_REPO}/archive/refs/tags/${TAG_VERSION}.tar.gz"
 
 curl -L -o "/tmp/eolang-${VERSION}.tar.gz" "$TARBALL_URL"

--- a/Formula/eolang.rb
+++ b/Formula/eolang.rb
@@ -7,9 +7,9 @@ require "language/node"
 class Eolang < Formula
   desc "Command-line Tool-Kit"
   homepage "https://github.com/objectionary/eoc"
-  url "https://github.com/objectionary/eoc/archive/refs/tags/0.34.0.tar.gz"
-  version "0.33.1"
-  sha256 "d29276ab1c51ac3195fd10fb9578c86851bfc2f49a3a6cce6c2d1c3adb72e7aa"
+  url "https://github.com/objectionary/eoc/archive/refs/tags/0.34.1.tar.gz"
+  version "0.34.1"
+  sha256 "ecf7f19115086fadbe1785b789378928d81dc8f0e3aa154b268f3a747c80fd01"
   license "MIT"
 
   depends_on "node"

--- a/Formula/eolang@0.32.0.rb
+++ b/Formula/eolang@0.32.0.rb
@@ -4,12 +4,12 @@
 #
 
 require "language/node"
-class Eolang < Formula
+class EolangAT0320 < Formula
   desc "Command-line Tool-Kit"
   homepage "https://github.com/objectionary/eoc"
-  url "https://github.com/objectionary/eoc/archive/refs/tags/0.34.0.tar.gz"
+  url "https://github.com/objectionary/eoc/archive/refs/tags/0.32.0.tar.gz"
   version "0.32.0"
-  sha256 "d29276ab1c51ac3195fd10fb9578c86851bfc2f49a3a6cce6c2d1c3adb72e7aa"
+  sha256 "a24da178f48e1e64280aa467fd97986d9456a25ea023525bf36a9308ec1a4cea"
   license "MIT"
 
   depends_on "node"

--- a/Formula/eolang@0.32.1.rb
+++ b/Formula/eolang@0.32.1.rb
@@ -4,12 +4,12 @@
 #
 
 require "language/node"
-class Eolang < Formula
+class EolangAT0321 < Formula
   desc "Command-line Tool-Kit"
   homepage "https://github.com/objectionary/eoc"
-  url "https://github.com/objectionary/eoc/archive/refs/tags/0.34.0.tar.gz"
+  url "https://github.com/objectionary/eoc/archive/refs/tags/0.32.1.tar.gz"
   version "0.32.1"
-  sha256 "d29276ab1c51ac3195fd10fb9578c86851bfc2f49a3a6cce6c2d1c3adb72e7aa"
+  sha256 "6770b4eb3068b5675e2f8c1cce580693f2ad844c6f9472fd2e236f81ba356ab2"
   license "MIT"
 
   depends_on "node"

--- a/Formula/eolang@0.33.0.rb
+++ b/Formula/eolang@0.33.0.rb
@@ -4,12 +4,12 @@
 #
 
 require "language/node"
-class Eolang < Formula
+class EolangAT0330 < Formula
   desc "Command-line Tool-Kit"
   homepage "https://github.com/objectionary/eoc"
-  url "https://github.com/objectionary/eoc/archive/refs/tags/0.34.0.tar.gz"
+  url "https://github.com/objectionary/eoc/archive/refs/tags/0.33.0.tar.gz"
   version "0.33.0"
-  sha256 "d29276ab1c51ac3195fd10fb9578c86851bfc2f49a3a6cce6c2d1c3adb72e7aa"
+  sha256 "6e01b4d88ba92018c359fa0bffc3a23742610de454107a7605cd2eecb9ba9a33"
   license "MIT"
 
   depends_on "node"

--- a/renovate.json
+++ b/renovate.json
@@ -7,5 +7,8 @@
     "org.apache.maven.plugins:maven-compiler-plugin",
     "org.eolang:eo-maven-plugin",
     "org.eolang:eo-runtime"
+  ],
+  "ignorePaths": [
+    "Formula/**"
   ]
 }


### PR DESCRIPTION
This PR fixes several significant bugs related to the publishing new formulas for Homebrew.

1. It tells to renovate to ignore the `Formula` directory, because it leads to the following bugs:

https://github.com/objectionary/eoc/pull/863

2. It fixes versions, urls and sha256 hashes in the existing formulas (that were damaged by this [PR](https://github.com/objectionary/eoc/pull/863) as well)

3. It fixes the bug with incorrect class names in the formulas that were generated by [homebrew_formula_up.sh](https://github.com/objectionary/eoc/blob/master/.github/homebrew_formula_up.sh):

To be able to install a particular formula version, the class name should be `EolangAT0330` that corresponds to the `0.33.0` version.

```
brew install local/eoc/eolang@0.33.0
Error: No available formula with the name "local/eoc/eolang@0.33.0". Did you mean local/eoc/eolang@0.32.0, local/eoc/eolang@0.32.1 or local/eoc/eolang?
In formula file: /usr/local/Homebrew/Library/Taps/local/homebrew-eoc/Formula/eolang@0.33.0.rb
Expected to find class EolangAT0330, but only found: Eolang.
```


Fixes #880