### PR TITLE
Fix extraFlags reference error in lint command

### DIFF
--- a/src/commands/lint.js
+++ b/src/commands/lint.js
@@ -15,7 +15,7 @@ const semver = require('semver');
  * @return {Promise} of assemble task
  */
 module.exports = function(opts) {
-  const extra = extraFlags(opts);
+  const extra = extras(opts);
   return elapsed(async (tracked) => {
     if (goals(opts)[0] === 'eo:lint') {
       try {

--- a/test/commands/test_lint.js
+++ b/test/commands/test_lint.js
@@ -6,9 +6,15 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const lint = require('../../src/commands/lint');
 const {runSync, assertFilesExist, parserVersion, homeTag, weAreOnline} = require('../helpers');
 
 describe('lint', () => {
+  it('extras returns failOnWarning flag', (done) => {
+    assert.deepEqual(lint.extras({easy: false}), ['-Deo.failOnWarning=true']);
+    assert.deepEqual(lint.extras({easy: true}), ['-Deo.failOnWarning=false']);
+    done();
+  });
   before(weAreOnline);
   it('lints a simple .EO program', (done) => {
     const home = path.resolve('temp/test-lint/simple');


### PR DESCRIPTION
Fixes #905.

`lint.js` called `extraFlags(opts)` on line 18, but the function is defined and exported as `extras`. This caused a `ReferenceError` whenever `eoc lint` was invoked.

**Changes:**
- Renamed the call from `extraFlags(opts)` to `extras(opts)` in `src/commands/lint.js`
- Added a unit test for `lint.extras` to verify it returns the correct Maven flag