### PR TITLE
#94 Enable slf4j-simple timestamps for Maven logs

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -91,6 +91,8 @@ module.exports.mvnw = function(args, tgt, batch) {
       '--color=never',
       '--fail-fast',
       '--strict-checksums',
+      '-Dorg.slf4j.simpleLogger.showDateTime=true',
+      '-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss',
     ]);
     const cmd = `${bin} ${params.join(' ')}`;
     console.debug('+ %s', cmd);


### PR DESCRIPTION
## Summary

Closes #94.

Since Maven 3.1.x the distribution ships with `slf4j-simple` as the active SLF4J implementation, which ignores the `log4j` configuration applied by `eo-maven-plugin`. As a result, `eoc` output lacks per-line timestamps even though log4j formatting already sets them up.

Passing the slf4j-simple system properties directly to every `mvnw` invocation makes the active logger emit timestamps in the `yyyy-MM-dd HH:mm:ss` format, matching the approach suggested in the issue.

## Changes

- `src/mvnw.js`: append `-Dorg.slf4j.simpleLogger.showDateTime=true` and `-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss` to every `mvnw` command in the shared `params` builder.

## Test plan

- [x] `npx mocha test/test_mvnw.js` — all 3 tests pass, and debug output confirms the flags are included in the constructed Maven command.
- [x] `npx eslint src/mvnw.js` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)