### PR TITLE
#912: fix `elapsed` minutes divisor (use 60_000, not 3_600_000)

### DIFF
--- a/src/elapsed.js
+++ b/src/elapsed.js
@@ -29,7 +29,7 @@ module.exports.elapsed = function elapsed(task) {
       } else if (duration < 60 * 1000) {
         extended = `${Math.ceil(duration / 1000)}s`;
       } else {
-        extended = `${Math.ceil(duration / 3600000)}min`;
+        extended = `${Math.ceil(duration / (60 * 1000))}min`;
       }
       const msg = `${message} in ${extended}`;
       console.info(msg);

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -200,7 +200,7 @@ function print() {
   } else if (duration < 60 * 1000) {
     elapsed = `${Math.ceil(duration / 1000)}s`;
   } else {
-    elapsed = `${Math.ceil(duration / 3600000)}min`;
+    elapsed = `${Math.ceil(duration / (60 * 1000))}min`;
   }
   process.stdout.write(
     colors.yellow(`[${phase}] ${elapsed}; ${count(target, 0)} files generated so far...`)

--- a/test/test_elapsed.js
+++ b/test/test_elapsed.js
@@ -8,6 +8,25 @@ const assert = require('assert');
 
 describe('elapsed', () => {
   const snooze = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  /**
+   * Stub Date.now so the first invocation returns 0 and the next returns
+   * the given duration in milliseconds. This lets us simulate long
+   * elapsed times without actually waiting.
+   * @param {Number} duration - Pretended elapsed time in ms.
+   * @return {Function} Restore function that puts back the original Date.now.
+   */
+  const stubNow = (duration) => {
+    const original = Date.now;
+    let calls = 0;
+    Date.now = () => {
+      const value = calls === 0 ? 0 : duration;
+      calls += 1;
+      return value;
+    };
+    return () => {
+      Date.now = original;
+    };
+  };
   it('measures time correctly', async () => {
     const actual = await elapsed(async (tracked) => {
       await snooze(333);
@@ -37,6 +56,33 @@ describe('elapsed', () => {
       /long task in 2s/.test(actual),
       `Expected "${actual}" to match /long task in 2s/`
     );
+  });
+  it('reports a 5-minute task in minutes, not in fractional hours', () => {
+    const restore = stubNow(5 * 60 * 1000);
+    try {
+      const actual = elapsed((tracked) => tracked.print('long task'));
+      assert.strictEqual(actual, 'long task in 5min');
+    } finally {
+      restore();
+    }
+  });
+  it('rounds a sub-minute-multiple duration up to the next minute', () => {
+    const restore = stubNow(3 * 60 * 1000 + 12 * 1000);
+    try {
+      const actual = elapsed((tracked) => tracked.print('odd task'));
+      assert.strictEqual(actual, 'odd task in 4min');
+    } finally {
+      restore();
+    }
+  });
+  it('reports exactly 1 minute when the duration is 60s', () => {
+    const restore = stubNow(60 * 1000);
+    try {
+      const actual = elapsed((tracked) => tracked.print('boundary task'));
+      assert.strictEqual(actual, 'boundary task in 1min');
+    } finally {
+      restore();
+    }
   });
   it('handles errors in task correctly', async () => {
     await assert.rejects(


### PR DESCRIPTION
@yegor256 this is ready for review.

## What this PR does

Fixes #912. `elapsed.print(...)` (in `src/elapsed.js`) and the inner `print()` in `src/mvnw.js` formatted durations >= 60s as `${Math.ceil(duration / 3600000)}min`. `3600000` is the number of milliseconds in an *hour*, not a minute, so any build between 1 minute and 2 hours rendered as `1min` regardless of how long it actually took. Both call sites now divide by `60 * 1000`, so a 5-minute build correctly shows `5min`.

## Files changed

- `src/elapsed.js` — divisor on the `>= 60s` branch (1 line).
- `src/mvnw.js` — divisor on the `>= 60s` branch (1 line).
- `test/test_elapsed.js` — three regression tests covering the minutes branch (60s, 3m12s, 5m) by stubbing `Date.now` so the test runs in milliseconds rather than waiting minutes of wall clock.

The two production fixes are deliberately separated from the test commit:

- `01fbe73` adds the failing regression tests (they fail on master).
- `e4b8174` applies the one-character-each fix in both files; tests then pass.

## Verification

- `npx mocha test/test_elapsed.js` locally: 7 passing. The three new tests fail before the fix (e.g. `'long task in 1min' !== 'long task in 5min'`) and pass after.
- `npx eslint` clean on the modified files.
- All 16 CI checks green on this branch (lints, eslint, pdd, xcop, reuse, markdown-lint, yamllint, typos, copyrights, shellcheck, actionlint, `itest` on ubuntu/windows/macos, `build` on ubuntu/windows/macos).

## Why no `mvnw.js` test

`mvnw.js`'s `print()` is an inner function that's not exported, and exposing it just to test the same divisor would be more invasive than the bug warrants. The fault is identical (same divisor, same string template) — the test on `elapsed.js` exercises the shared formatting logic; the `mvnw.js` change is a 1-character mirror of that fix.
