### PR TITLE
#566: add --object option to test command for single test execution

### DIFF
--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -22,7 +22,7 @@ module.exports = function(opts, maven = mvnw) {
     const method = parts.pop().replace(/-/g, '_');
     const obj = parts.pop().replace(/-/g, '_');
     const pkg = parts.map((p) => `EO${p.replace(/-/g, '_')}`).join('.');
-    const cls = `EO${obj}TestTest`;
+    const cls = `EO${obj}*Test`;
     args.push(`-Dtest=${pkg ? `org.eolang.${pkg}.${cls}` : `org.eolang.${cls}`}#${method}`);
   }
   return maven(args.concat(flags(opts)));

--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -19,10 +19,11 @@ module.exports = function(opts, maven = mvnw) {
   ];
   if (opts.object) {
     const parts = opts.object.split('.');
+    const method = parts.pop().replace(/-/g, '_');
     const obj = parts.pop().replace(/-/g, '_');
     const pkg = parts.map((p) => `EO${p.replace(/-/g, '_')}`).join('.');
-    const cls = `EO${obj}Test`;
-    args.push(`-Dtest=${pkg ? `org.eolang.${pkg}.${cls}` : `org.eolang.${cls}`}`);
+    const cls = `EO${obj}TestTest`;
+    args.push(`-Dtest=${pkg ? `org.eolang.${pkg}.${cls}` : `org.eolang.${cls}`}#${method}`);
   }
   return maven(args.concat(flags(opts)));
 };

--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -8,14 +8,21 @@ const {mvnw, flags} = require('../../mvnw');
 /**
  * Command to run all available unit tests.
  * @param {Object} opts - All options
+ * @param {Function} maven - Maven runner, defaults to mvnw
  * @return {Promise} of compile task
  */
-module.exports = function(opts) {
-  return mvnw(
-    [
-      'surefire:test',
-      `-Dstack-size=${opts.stack}`,
-      `-Dheap-size=${opts.heap}`,
-    ].concat(flags(opts))
-  );
+module.exports = function(opts, maven = mvnw) {
+  const args = [
+    'surefire:test',
+    `-Dstack-size=${opts.stack}`,
+    `-Dheap-size=${opts.heap}`,
+  ];
+  if (opts.object) {
+    const parts = opts.object.split('.');
+    const obj = parts.pop().replace(/-/g, '_');
+    const pkg = parts.map((p) => `EO${p.replace(/-/g, '_')}`).join('.');
+    const cls = `EO${obj}Test`;
+    args.push(`-Dtest=${pkg ? `org.eolang.${pkg}.${cls}` : `org.eolang.${cls}`}`);
+  }
+  return maven(args.concat(flags(opts)));
 };

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -265,6 +265,7 @@ program.command('test')
   .description('Run all visible unit tests')
   .option('--stack <size>', 'Set stack size for the virtual machine', '64M')
   .option('--heap <size>', 'Set the heap size for the VM', '256M')
+  .option('--object <name>', 'Run a single test object by its full EO name, e.g. foo.app.works-fine')
   .action(async (str, opts) => {
     pin(program.opts());
     clear(str);

--- a/test/commands/java/test_test.js
+++ b/test/commands/java/test_test.js
@@ -1,0 +1,42 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+const assert = require('assert');
+const test = require('../../../src/commands/java/test');
+
+describe('java/test', () => {
+  it('builds -Dtest filter from --object with package', async () => {
+    let captured;
+    await test(
+      {stack: '64M', heap: '256M', sources: 'src', target: 'target', object: 'foo.app.works-fine'},
+      (args) => { captured = args; }
+    );
+    assert.ok(
+      captured.includes('-Dtest=org.eolang.EOfoo.EOapp.EOworks_fineTest'),
+      `expected -Dtest=org.eolang.EOfoo.EOapp.EOworks_fineTest, got: ${captured}`
+    );
+  });
+  it('builds -Dtest filter from --object without package', async () => {
+    let captured;
+    await test(
+      {stack: '64M', heap: '256M', sources: 'src', target: 'target', object: 'works-fine'},
+      (args) => { captured = args; }
+    );
+    assert.ok(
+      captured.includes('-Dtest=org.eolang.EOworks_fineTest'),
+      `expected -Dtest=org.eolang.EOworks_fineTest, got: ${captured}`
+    );
+  });
+  it('omits -Dtest when --object is not provided', async () => {
+    let captured;
+    await test(
+      {stack: '64M', heap: '256M', sources: 'src', target: 'target'},
+      (args) => { captured = args; }
+    );
+    assert.ok(
+      !captured.some((a) => a.startsWith('-Dtest=')),
+      `expected no -Dtest arg, got: ${captured}`
+    );
+  });
+});

--- a/test/commands/java/test_test.js
+++ b/test/commands/java/test_test.js
@@ -13,19 +13,19 @@ describe('java/test', () => {
       (args) => { captured = args; }
     );
     assert.ok(
-      captured.includes('-Dtest=org.eolang.EOfoo.EOapp.EOworks_fineTest'),
-      `expected -Dtest=org.eolang.EOfoo.EOapp.EOworks_fineTest, got: ${captured}`
+      captured.includes('-Dtest=org.eolang.EOfoo.EOappTestTest#works_fine'),
+      `expected -Dtest=org.eolang.EOfoo.EOappTestTest#works_fine, got: ${captured}`
     );
   });
   it('builds -Dtest filter from --object without package', async () => {
     let captured;
     await test(
-      {stack: '64M', heap: '256M', sources: 'src', target: 'target', object: 'works-fine'},
+      {stack: '64M', heap: '256M', sources: 'src', target: 'target', object: 'app.works-fine'},
       (args) => { captured = args; }
     );
     assert.ok(
-      captured.includes('-Dtest=org.eolang.EOworks_fineTest'),
-      `expected -Dtest=org.eolang.EOworks_fineTest, got: ${captured}`
+      captured.includes('-Dtest=org.eolang.EOappTestTest#works_fine'),
+      `expected -Dtest=org.eolang.EOappTestTest#works_fine, got: ${captured}`
     );
   });
   it('omits -Dtest when --object is not provided', async () => {

--- a/test/commands/java/test_test.js
+++ b/test/commands/java/test_test.js
@@ -13,8 +13,8 @@ describe('java/test', () => {
       (args) => { captured = args; }
     );
     assert.ok(
-      captured.includes('-Dtest=org.eolang.EOfoo.EOappTestTest#works_fine'),
-      `expected -Dtest=org.eolang.EOfoo.EOappTestTest#works_fine, got: ${captured}`
+      captured.includes('-Dtest=org.eolang.EOfoo.EOapp*Test#works_fine'),
+      `expected -Dtest=org.eolang.EOfoo.EOapp*Test#works_fine, got: ${captured}`
     );
   });
   it('builds -Dtest filter from --object without package', async () => {
@@ -24,8 +24,8 @@ describe('java/test', () => {
       (args) => { captured = args; }
     );
     assert.ok(
-      captured.includes('-Dtest=org.eolang.EOappTestTest#works_fine'),
-      `expected -Dtest=org.eolang.EOappTestTest#works_fine, got: ${captured}`
+      captured.includes('-Dtest=org.eolang.EOapp*Test#works_fine'),
+      `expected -Dtest=org.eolang.EOapp*Test#works_fine, got: ${captured}`
     );
   });
   it('omits -Dtest when --object is not provided', async () => {

--- a/test/commands/test_test.js
+++ b/test/commands/test_test.js
@@ -18,7 +18,7 @@ describe('test', () => {
    * @param {String} hash - Git SHA in objectionary/home
    * @return {String} - Stdout
    */
-  const test = function(home, lang = 'Java', parser, hash) {
+  const test = function(home, lang = 'Java', parser, hash, args = []) {
     fs.rmSync(home, {recursive: true, force: true});
     fs.mkdirSync(path.resolve(home, 'src'), {recursive: true});
     fs.writeFileSync(
@@ -45,7 +45,8 @@ describe('test', () => {
       '--heap=128M',
       '-s', path.resolve(home, 'src'),
       '-t', path.resolve(home, 'target'),
-      `--language=${lang}`
+      `--language=${lang}`,
+      ...args,
     ]);
   };
   it('executes a single Java unit test', (done) => {
@@ -69,6 +70,15 @@ describe('test', () => {
     assert.ok(stdout.includes('1 passing'));
     assertFilesExist(
       stdout, home, ['target/project/simple-test.test.js',]
+    );
+    done();
+  });
+  it('runs only the specified test when --object is provided', (done) => {
+    const home = path.resolve('temp/test-test/object-filter'),
+      stdout = test(home, 'Java', parserVersion, homeTag, ['--object', 'simple.works-correctly']);
+    assert.ok(
+      stdout.includes('Tests run: 1, Failures: 0, Errors: 0, Skipped: 0'),
+      `expected exactly 1 test to run, got: ${stdout}`
     );
     done();
   });


### PR DESCRIPTION
Closes #566.

Running `eoc test` always executes all visible unit tests. There is no way to run a single test object in isolation, which slows down the feedback loop when working on a specific test.

This PR adds `--object <name>` option to the `test` command. The full EO object path (e.g. `foo.app.works-fine`) is converted to a Maven Surefire `-Dtest=` filter that targets the corresponding JUnit test class and method.

The conversion accounts for both naming conventions produced by the EO transpiler:
- objects without `+tests` → `EO${name}Test`
- objects with `+tests` → `EO${name}TestTest`

A wildcard pattern `EO${name}*Test#${method}` is used to cover both cases.

## Changes

- `src/eoc.js`: add `--object <name>` option to the `test` command
- `src/commands/java/test.js`: convert EO object path to Surefire filter; accept optional `maven` parameter for testability
- `test/commands/java/test_test.js`: unit tests for the conversion logic
- `test/commands/test_test.js`: itest verifying that exactly one test runs when `--object` is provided

## Test plan

- [x] `npx mocha test/commands/java/test_test.js` — 3 unit tests pass
- [x] `npx mocha test/commands/test_test.js --grep "object" --timeout 300000` — itest passes, `Tests run: 1`
- [x] `npx eslint .` — clean