### PR TITLE
#913: enforce --pin on link and jeo:assemble

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -234,6 +234,7 @@ program.command('compile')
 program.command('link')
   .description('Link together all binaries into a single executable binary')
   .action(async (str, opts) => {
+    pin(program.opts());
     clear(str);
     if (program.opts().alone === undefined) {
       await pipe()(coms(), ['register', 'assemble', 'lint', 'resolve', 'transpile', 'compile', 'link'], program.opts());
@@ -341,6 +342,7 @@ program.command('jeo:assemble')
     'classes'
   )
   .action((str, opts) => {
+    pin(program.opts());
     coms().jeo_assemble({...program.opts(), ...str});
   });
 

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -59,3 +59,21 @@ describe('eoc', () => {
     done();
   });
 });
+
+describe('eoc', () => {
+  before(weAreOnline);
+  it('fails link due to version mismatch if different --pin provided', (done) => {
+    assert.throws(
+      () => { runSync(['--pin=29.9.4', '--alone', 'link']); },
+      /Version mismatch: you are running eoc [0-9]+\.[0-9]+\.[0-9]+, but --pin option requires 29.9.4/
+    );
+    done();
+  });
+  it('fails jeo:assemble due to version mismatch if different --pin provided', (done) => {
+    assert.throws(
+      () => { runSync(['--pin=29.9.4', 'jeo:assemble']); },
+      /Version mismatch: you are running eoc [0-9]+\.[0-9]+\.[0-9]+, but --pin option requires 29.9.4/
+    );
+    done();
+  });
+});


### PR DESCRIPTION
@yegor256 this PR fixes #913.

## Problem

In `src/eoc.js`, every build command except `link` and `jeo:assemble` calls `pin(program.opts())` as the first statement of its action handler — that's the helper that compares `--pin=X.Y.Z` against the running `eoc` version and exits 1 with `Version mismatch: ...` on a mismatch. Because `link` and `jeo:assemble` were missing that call, a project pinned to a specific `eoc` version would silently bypass the version check when those two commands were invoked.

## Changes

Two small commits:

1. `#913: add failing tests for --pin on link and jeo:assemble` — adds two regression tests in `test/test_eoc.js` that invoke `eoc --pin=29.9.4 --alone link` and `eoc --pin=29.9.4 jeo:assemble`, asserting the standard `Version mismatch: you are running eoc <X.Y.Z>, but --pin option requires 29.9.4` error is raised. Without the fix both tests fail: `link --alone` runs to completion silently, and `jeo:assemble` fails downstream inside Maven for an unrelated reason.

2. `#913: enforce --pin in link and jeo:assemble action handlers` — adds `pin(program.opts())` as the first statement of each handler, mirroring the pattern used by `compile`, `transpile`, `clean`, `register`, `parse`, `assemble`, `lint`, `resolve`, `dataize`, `test`, `print`, `docs`, `jeo:disassemble`, `latex`, `normalize`, and `fmt`.

Net diff: +2 lines in `src/eoc.js`, +18 lines in `test/test_eoc.js`.

## Verification

- `npx eslint` — clean.
- `npx mocha test/test_eoc.js` — all 8 tests pass (6 pre-existing + 2 new).
- All 16 CI checks green on this PR (grunt build × 3 OSes, itest × 3 OSes, eslint, typos, pdd, xcop, copyrights, reuse, yamllint, markdown-lint, shellcheck, actionlint).

Ready for merge.