### PR TITLE
fix(#678): detect missing javac early with a clear diagnostic

### DIFF
--- a/src/commands/java/compile.js
+++ b/src/commands/java/compile.js
@@ -5,6 +5,7 @@
 const rel = require('relative');
 const {mvnw, flags} = require('../../mvnw');
 const {elapsed} = require('../../elapsed');
+const {verifyJavac} = require('../../jdk');
 const path = require('path');
 
 /**
@@ -13,6 +14,7 @@ const path = require('path');
  * @return {Promise} of compile task
  */
 module.exports = function(opts) {
+  verifyJavac();
   const target = path.resolve(opts.target);
   return elapsed(async (tracked) => {
     const r = await mvnw(goals().concat(flags(opts)), opts.target, opts.batch);

--- a/src/commands/java/link.js
+++ b/src/commands/java/link.js
@@ -6,6 +6,7 @@
 const rel = require('relative');
 const {mvnw, flags} = require('../../mvnw');
 const {elapsed} = require('../../elapsed');
+const {verifyJavac} = require('../../jdk');
 const path = require('path');
 
 /**
@@ -14,6 +15,7 @@ const path = require('path');
  * @return {Promise} of link task
  */
 module.exports = function(opts) {
+  verifyJavac();
   const jar = path.resolve(opts.target, 'eoc.jar');
   return elapsed(async (tracked) => {
     const r = await mvnw(goals().concat(flags(opts)), opts.target, opts.batch);

--- a/src/commands/java/pipeline.js
+++ b/src/commands/java/pipeline.js
@@ -5,6 +5,16 @@
 
 const {mvnw, flags} = require('../../mvnw');
 const {elapsed} = require('../../elapsed');
+const {verifyJavac} = require('../../jdk');
+
+/**
+ * Commands whose Maven goals require `javac` to be on the PATH.
+ * Anything that triggers the maven-compiler-plugin (or surefire test
+ * compilation) must be listed here so we can fail fast with a clear
+ * diagnostic instead of letting Maven die with `release version 11
+ * not supported`.
+ */
+const JAVAC_COMMANDS = ['compile', 'link', 'test'];
 
 /**
  * Runs multiple Maven goals in a single Maven invocation.
@@ -14,6 +24,9 @@ const {elapsed} = require('../../elapsed');
  * @return {Promise} of pipeline task
  */
 module.exports = function(coms, commands, opts, maven = mvnw) {
+  if (commands.some((cmd) => JAVAC_COMMANDS.includes(cmd))) {
+    verifyJavac();
+  }
   return elapsed(async (tracked) => {
     const {goals, extras} = collect(coms, commands, opts);
     const result = await maven(goals.concat(flags(opts)).concat(extras), opts.target, opts.batch);

--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -4,6 +4,7 @@
  */
 
 const {mvnw, flags} = require('../../mvnw');
+const {verifyJavac} = require('../../jdk');
 
 /**
  * Command to run all available unit tests.
@@ -12,6 +13,7 @@ const {mvnw, flags} = require('../../mvnw');
  * @return {Promise} of compile task
  */
 module.exports = function(opts, maven = mvnw) {
+  verifyJavac();
   const args = [
     'surefire:test',
     `-Dstack-size=${opts.stack}`,

--- a/src/jdk.js
+++ b/src/jdk.js
@@ -1,0 +1,65 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const {execSync} = require('child_process');
+
+/**
+ * Default executor used when no override is supplied. Runs the command
+ * synchronously, captures its output, and returns it as a Buffer.
+ * Stderr is captured (javac prints its version to stderr) so we can
+ * surface it back if anything goes wrong.
+ *
+ * @param {String} cmd - The command to execute.
+ * @return {Buffer} The combined stdout/stderr output.
+ */
+function defaultExec(cmd) {
+  return execSync(cmd, {stdio: ['ignore', 'pipe', 'pipe']});
+}
+
+/**
+ * Build the user-facing error message that we want to print when
+ * `javac` cannot be located or executed. The message lists the
+ * common ways to install a full JDK on each platform, since the
+ * most common cause of this error is that the user has installed
+ * a JRE (or none at all) instead of a JDK.
+ *
+ * @param {Error} cause - The underlying error from the exec attempt.
+ * @return {String} The user-facing diagnostic.
+ */
+function missingJavacMessage(cause) {
+  const lines = [
+    '`javac` was not found on your PATH.',
+    'EO needs a full JDK (not just a JRE) to compile Java sources.',
+    'Please install OpenJDK 11 or newer and make sure `javac` is on your PATH.',
+    '  Debian/Ubuntu: sudo apt-get install openjdk-21-jdk',
+    '  macOS:         brew install --cask temurin',
+    '  Windows:       https://adoptium.net/'
+  ];
+  if (cause && cause.message) {
+    lines.push(`Underlying error: ${cause.message.toString().trim()}`);
+  }
+  return lines.join('\n');
+}
+
+/**
+ * Verify that `javac` is available on the current PATH. Throws an
+ * Error with a clear, actionable message when it is not, and is a
+ * no-op otherwise. The actual command runner is injectable so that
+ * tests can stub it out without spawning a real subprocess.
+ *
+ * @param {Function} [exec] - Optional command runner (mainly for tests).
+ *                            Should accept a single string command and
+ *                            either return the captured output or throw
+ *                            on non-zero exit.
+ * @return {void}
+ */
+module.exports.verifyJavac = function(exec) {
+  const run = exec || defaultExec;
+  try {
+    run('javac -version');
+  } catch (cause) {
+    throw new Error(missingJavacMessage(cause), {cause});
+  }
+};

--- a/test/test_jdk.js
+++ b/test/test_jdk.js
@@ -1,0 +1,54 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+const {verifyJavac} = require('../src/jdk');
+
+describe('jdk', () => {
+  it('throws a clear error when javac is not on the PATH', () => {
+    const fakeExec = () => {
+      const err = new Error('spawnSync javac ENOENT');
+      err.code = 'ENOENT';
+      throw err;
+    };
+    assert.throws(
+      () => verifyJavac(fakeExec),
+      (error) => {
+        assert(error instanceof Error);
+        assert(
+          /javac/.test(error.message),
+          `Expected error message to mention "javac": ${error.message}`
+        );
+        assert(
+          /JDK/.test(error.message),
+          `Expected error message to mention "JDK": ${error.message}`
+        );
+        assert(
+          /PATH/.test(error.message),
+          `Expected error message to mention "PATH": ${error.message}`
+        );
+        return true;
+      }
+    );
+  });
+  it('returns silently when javac is available', () => {
+    const fakeExec = () => Buffer.from('javac 21.0.10\n');
+    assert.doesNotThrow(() => verifyJavac(fakeExec));
+  });
+  it('surfaces the underlying failure message when javac exits non-zero', () => {
+    const fakeExec = () => {
+      const err = new Error('Command failed: javac -version\n/bin/sh: 1: javac: not found\n');
+      err.status = 127;
+      throw err;
+    };
+    assert.throws(
+      () => verifyJavac(fakeExec),
+      (error) => {
+        assert(/javac/.test(error.message));
+        return true;
+      }
+    );
+  });
+});


### PR DESCRIPTION
@yegor256 ready for review.

Closes #678 once merged.

## What

Adds a small `verifyJavac()` helper (`src/jdk.js`) that runs `javac -version` and, on failure, throws an `Error` whose message says `javac` is not on the `PATH`, that EO needs a full **JDK** (not a JRE), and how to install one on Debian/Ubuntu, macOS, and Windows. The helper is wired into the four entry points whose Maven invocation triggers `maven-compiler-plugin` (or surefire test compilation):

| Entry point | When it fires |
|---|---|
| `src/commands/java/pipeline.js` | Whenever the pipeline includes `compile`, `link`, or `test` (i.e. `eoc compile`, `eoc link`, `eoc dataize`, `eoc test` without `--alone`) |
| `src/commands/java/compile.js` | `eoc compile --alone` |
| `src/commands/java/link.js` | `eoc link --alone` |
| `src/commands/java/test.js` | `eoc test --alone` |

Purely-EO entry points (`parse`, `register`, `lint`, `resolve`, `transpile`, etc.) do **not** gain a new prerequisite — the check only runs when we are about to ask Maven to compile something.

## Why

Per the issue thread, when a user has only a JRE (or nothing at all) on their `PATH`, `eoc compile` / `eoc link` / `eoc dataize` blows up deep inside Maven with

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:compile
        (default-compile) on project eoc:
        Fatal error compiling: error: release version 11 not supported
```

which gives the user no clue that the actual problem is "install a JDK." With this PR, they instead see something like:

```
`javac` was not found on your PATH.
EO needs a full JDK (not just a JRE) to compile Java sources.
Please install OpenJDK 11 or newer and make sure `javac` is on your PATH.
  Debian/Ubuntu: sudo apt-get install openjdk-21-jdk
  macOS:         brew install --cask temurin
  Windows:       https://adoptium.net/
Underlying error: Command failed: javac -version …
```

## How

`verifyJavac()` accepts an injectable `exec` argument so it can be unit-tested without spawning a real subprocess. The default executor uses `child_process.execSync` with stderr captured (javac prints its version to stderr), so on failure the underlying error message is preserved as `Error.cause` and surfaced to the user.

## Tests

- Two commits: `test(#678): add failing test for jdk.verifyJavac diagnostic` lands the assertions first; `fix(#678): …` adds the implementation.
- New `test/test_jdk.js` covers three scenarios with stubbed executors:
  1. `javac` is missing — error mentions `javac`, `JDK`, and `PATH`.
  2. `javac` is present — `verifyJavac()` returns silently.
  3. `javac` exits non-zero — message still references `javac` and surfaces the underlying error.
- Existing `test/commands/java/test_pipeline.js` continues to pass (its three scenarios use commands outside the `compile`/`link`/`test` set, so they don't trigger the JDK check).
- `npx eslint .` is clean.
- All 16 GitHub-Actions checks are green: `actionlint`, `build` × 3 OSes, `copyrights`, `eslint`, `itest` × 3 OSes, `markdown-lint`, `pdd`, `reuse`, `shellcheck`, `typos`, `xcop`, `yamllint`.

## Out of scope

- Detecting `javac` versions older than what the EO toolchain currently targets (release 11). The current EO releases set their own `--release`; if a future bump needs us to also enforce a *minimum* `javac` version, that's a follow-up.
- Translating Maven's existing failure messages — once `verifyJavac()` runs first, the "release version 11 not supported" path is unreachable from a clean install.
