### PR TITLE
Document missing pipeline commands in README (#857)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,11 @@ You can also do many other things with `eoc` commands
 (the flow is explained in [this blog post][blog]):
 
 * `register` finds necessary `.eo` files and registers them in a JSON catalog
+* `parse` parses `.eo` files into `.xmir` without pulling foreign objects
 * `assemble` parses `.eo` files into `.xmir`, optimizes them,
   and pulls foreign EO objects
+* `lint` finds style-related errors in EO and XMIR files
+* `resolve` resolves all the dependencies required for compilation
 * `transpile` converts `.xmir` files to the target programming
 language (Java by default)
 * `compile` converts target language sources (e.g., `.java`)
@@ -125,7 +128,6 @@ to binaries (e.g., `.class`)
 * `link` puts all binaries together into a single executable binary
 * `dataize` dataizes a single object from the executable binary
 * `test` dataizes all visible unit tests
-* `lint` finds style-related errors in EO and XMIR files
 * `jeo:disassemble` converts Java `.class` files to `.xmir`
 (via [jeo](https://github.com/objectionary/jeo-maven-plugin))
 * `jeo:assemble` converts `.xmir` files to Java `.class` files
@@ -135,6 +137,7 @@ There are also commands that help manipulate with XMIR and EO sources
 (the list is not completed, while some of them are not implemented as of yet):
 
 * `audit` inspects all required packages and reports their status
+* `clean` deletes all temporary files (use `--global` to also delete `~/.eo`)
 * `foreign` inspects all objects found in the program after the `assemble` step
 * `print` generates `.eo` files from `.xmir` files
 * `generate_comments` generates `.json` files with LLM-generated

--- a/test/test_readme.js
+++ b/test/test_readme.js
@@ -1,0 +1,36 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const {runSync} = require('./helpers');
+
+describe('README.md', () => {
+  it('mentions every command exposed by eoc --help', (done) => {
+    const help = runSync(['--help']);
+    const tail = help.split('\nCommands:\n')[1];
+    assert(tail, `eoc --help output has no "Commands:" section:\n${help}`);
+    const names = [];
+    for (const line of tail.split('\n')) {
+      const match = line.match(/^ {2}(?<name>[a-z][a-z_:]*)\b/);
+      if (match && match.groups.name !== 'help') {
+        names.push(match.groups.name);
+      }
+    }
+    assert(names.length > 0, `no commands extracted from --help:\n${help}`);
+    const readme = fs.readFileSync(
+      path.resolve(__dirname, '../README.md'), 'utf8'
+    );
+    const missing = names.filter((name) => !readme.includes(`\`${name}\``));
+    assert.deepStrictEqual(
+      missing, [],
+      `These commands are exposed by 'eoc --help' but are not mentioned in ` +
+      `README.md: ${missing.join(', ')}. Please document them in the ` +
+      `Commands section so the README stays in sync with the CLI.`
+    );
+    done();
+  });
+});


### PR DESCRIPTION
@yegor256 ready for merge — all 16 CI checks are green.

Closes #857.

The README's Commands section was hand-written and had drifted from the actual CLI: `clean`, `parse` and `resolve` are exposed by `eoc --help` but were not mentioned in `README.md`. As discussed in the issue, the goal is to keep the documentation in sync with the CLI automatically rather than relying on contributors to remember to update both.

This PR takes the test-driven approach you typically prefer here:

* `test/test_readme.js` runs `eoc --help`, parses its `Commands:` block, and asserts every command name (except the built-in `help`) appears in `README.md` between backticks. On `master` the test fails with `clean, parse, resolve` reported as missing.
* `README.md` is updated to document the three missing commands and `lint` is moved next to `assemble` so the bullet order matches the pipeline order in `src/eoc.js`.

Whenever a new `program.command(...)` is added in `src/eoc.js` (or one is renamed/removed) the test fails until the README catches up — same kind of CI guard #857 was asking for, without the editorial loss of switching to a fully generated section.

Two-commit history:
1. `test(#857): assert README mentions every command from eoc --help` — failing test that reproduces the drift.
2. `fix(#857): document the missing pipeline commands in README` — README change that turns the test green.