### PR TITLE
fix(#782): tolerate trailing bytes when reading eo-foreign.json

### DIFF
--- a/src/commands/foreign.js
+++ b/src/commands/foreign.js
@@ -8,14 +8,56 @@ const path = require('path');
 const fs = require('fs');
 
 /**
+ * Extract the first balanced JSON array from a string, ignoring any trailing
+ * bytes that may have been left over by a non-atomic writer (observed on
+ * Windows CI, see issue #782).
+ * @param {String} text - Raw file contents
+ * @return {String} Substring spanning the first complete `[...]` array
+ */
+function firstJsonArray(text) {
+  const body = text.charCodeAt(0) === 0xFEFF ? text.slice(1) : text;
+  let depth = 0;
+  let start = -1;
+  let inString = false;
+  let escape = false;
+  for (let i = 0; i < body.length; i += 1) {
+    const ch = body[i];
+    if (inString) {
+      if (escape) {
+        escape = false;
+      } else if (ch === '\\') {
+        escape = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+    } else if (ch === '"') {
+      inString = true;
+    } else if (ch === '[') {
+      if (depth === 0) {
+        start = i;
+      }
+      depth += 1;
+    } else if (ch === ']') {
+      depth -= 1;
+      if (depth === 0 && start >= 0) {
+        return body.slice(start, i + 1);
+      }
+    }
+  }
+  throw new SyntaxError('No complete JSON array found in foreign catalog');
+}
+
+/**
  * Inspects and prints the list of foreign objects.
  * @param {Hash} opts - All options
  */
 module.exports = function(opts) {
-  const file = path.resolve(opts.target, 'eo-foreign.json'),
-    all = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const file = path.resolve(opts.target, 'eo-foreign.json');
+  const all = JSON.parse(firstJsonArray(fs.readFileSync(file, 'utf8')));
   console.info('There are %d objects in %s:', all.length, rel(file));
   all.forEach((obj) => {
     console.info('  %s', obj.id);
   });
 };
+
+module.exports.firstJsonArray = firstJsonArray;

--- a/test/test_foreign_parse.js
+++ b/test/test_foreign_parse.js
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+const {firstJsonArray} = require('../src/commands/foreign');
+
+describe('foreign / firstJsonArray', () => {
+  it('returns the array verbatim when the input is clean JSON', () => {
+    const text = '[{"id":"a"},{"id":"b"}]';
+    assert.strictEqual(firstJsonArray(text), text);
+  });
+  it('tolerates leading whitespace and a UTF-8 BOM', () => {
+    const text = '﻿\n  [{"id":"a"}]\n';
+    assert.deepStrictEqual(JSON.parse(firstJsonArray(text)), [{id: 'a'}]);
+  });
+  it('returns only the first array when extra content is appended (issue #782)', () => {
+    const text = [
+      '[',
+      '    {"id": "app"}',
+      ']',
+      ' [',
+      '   {"id": "stale"}',
+      ' ]',
+      '',
+    ].join('\n');
+    const parsed = JSON.parse(firstJsonArray(text));
+    assert.deepStrictEqual(parsed, [{id: 'app'}]);
+  });
+  it('handles nested arrays inside object values', () => {
+    const text = '[{"id":"a","probed":"[1,2]"},{"id":"b"}]trailing';
+    const parsed = JSON.parse(firstJsonArray(text));
+    assert.strictEqual(parsed.length, 2);
+    assert.strictEqual(parsed[0].probed, '[1,2]');
+  });
+  it('throws when no array is present', () => {
+    assert.throws(() => firstJsonArray('not json at all'), SyntaxError);
+  });
+});


### PR DESCRIPTION
 Closes #782.

 Windows CI failed `test/commands/test_foreign.js` with:

 > Unexpected non-whitespace character after JSON at position 11819 (line 251 column 2)

 `JSON.parse` consumed a valid prefix and then tripped on trailing bytes after the closing `]`.

## Fix
 `src/commands/foreign.js` no longer feeds the raw file to `JSON.parse`. It scans for the first balanced `[...]` array (string-literal
 aware, BOM-tolerant) and parses only that — any trailing bytes from a non-atomic writer are ignored.

## Tests
New `test/test_foreign_parse.js` covers clean JSON, BOM / leading whitespace, the #782 symptom (valid array + a second concatenated
 array at "line N column 2"), nested arrays inside string values, and a negative case. The existing `test/commands/test_foreign.js` integration
 test still passes.

## Caveat
The corruption does not reproduce locally on Linux (the plugin writes clean JSON), so this is consumer-side hardening, not a
 root-cause fix — the underlying race likely lives in upstream `tojos` / Maven plugin and deserves its own investigation. Supersedes the
 cosmetic-only draft #785.
