### PR TITLE
#467: generate summary XML in docs command

### DIFF
--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -143,10 +143,12 @@ module.exports = function(opts) {
         if (!(packages in packages_info)) {
           packages_info[packages] = {
             xmir_htmls : [],
+            names: [],
             path: html_package
           };
         }
         packages_info[packages].xmir_htmls.push(xmir_html);
+        packages_info[packages].names.push(name);
         all_xmir_htmls.push(xmir_html);
       }
       for (const package_name of Object.keys(packages_info)) {
@@ -164,18 +166,14 @@ module.exports = function(opts) {
       ];
       for (const pkg of pkgNames) {
         lines.push(`  <package name="${xmlEscape(pkg)}">`);
-        for (const xmir of xmirs) {
-          const rel_path = path.relative(input, xmir);
-          if (path.dirname(rel_path).split(path.sep).join('.') === pkg) {
-            const name = path.parse(xmir).name;
-            lines.push(`    <object name="${xmlEscape(name)}"/>`);
-          }
+        for (const obj of packages_info[pkg].names) {
+          lines.push(`    <object name="${xmlEscape(obj)}"/>`);
         }
         lines.push('  </package>');
       }
       lines.push('</eodoc>');
       fs.writeFileSync(summary, lines.join('\n'));
-      tracked.print('Summary XML generated at %s', rel(summary));
+      tracked.print('Summary XML generated at %s', path.relative(process.cwd(), summary));
       tracked.print(`Documentation generation completed in the ${output} directory`);
     } catch (error) {
       console.error('Error generating documentation:', error);

--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -10,6 +10,17 @@ const { marked } = require('marked');
 const {elapsed} = require('../elapsed');
 const {findFiles} = require('../files');
 
+/**
+ * Escape special XML characters.
+ * @param {String} str - Raw string
+ * @return {String} XML-safe string
+ */
+function xmlEscape(str) {
+  return str.replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
 
 /**
  * Applies XSLT to XMIR
@@ -145,6 +156,26 @@ module.exports = function(opts) {
       }
       const packages = path.join(output, 'packages.html');
       fs.writeFileSync(packages, generatePackageHtml('overall package', all_xmir_htmls, css));
+      const summary = path.join(output, 'summary.xml');
+      const pkgNames = Object.keys(packages_info);
+      const lines = [
+        '<?xml version="1.0" encoding="UTF-8"?>',
+        `<eodoc packages="${pkgNames.length}" objects="${xmirs.length}">`
+      ];
+      for (const pkg of pkgNames) {
+        lines.push(`  <package name="${xmlEscape(pkg)}">`);
+        for (const xmir of xmirs) {
+          const rel_path = path.relative(input, xmir);
+          if (path.dirname(rel_path).split(path.sep).join('.') === pkg) {
+            const name = path.parse(xmir).name;
+            lines.push(`    <object name="${xmlEscape(name)}"/>`);
+          }
+        }
+        lines.push('  </package>');
+      }
+      lines.push('</eodoc>');
+      fs.writeFileSync(summary, lines.join('\n'));
+      tracked.print('Summary XML generated at %s', rel(summary));
       tracked.print(`Documentation generation completed in the ${output} directory`);
     } catch (error) {
       console.error('Error generating documentation:', error);

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -47,6 +47,31 @@ describe('docs', () => {
     done();
   });
   /**
+   * Tests that the 'docs' command generates a summary.xml with correct counts.
+   * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
+   */
+  it('generates summary XML with correct package and object counts', (done) => {
+    const sample = path.join(parsed, 'foo', 'bar');
+    fs.mkdirSync(sample, {recursive: true});
+    fs.writeFileSync(path.join(sample, 'test1.xmir'), '<program name="test" />');
+    fs.writeFileSync(path.join(sample, 'test2.xmir'), '<program name="test" />');
+    runSync([
+      'docs',
+      '--verbose',
+      '-s', path.resolve(home, 'src'),
+      '-t', home,
+    ]);
+    const summary = path.join(docs, 'summary.xml');
+    assert(fs.existsSync(summary), `Expected file ${summary} but it was not created`);
+    const content = fs.readFileSync(summary, 'utf-8');
+    assert(content.includes('packages="1"'), 'Expected 1 package in summary.xml');
+    assert(content.includes('objects="2"'), 'Expected 2 objects in summary.xml');
+    assert(content.includes('<package name="foo.bar">'), 'Expected package foo.bar in summary.xml');
+    assert(content.includes('<object name="test1"/>'), 'Expected object test1 in summary.xml');
+    assert(content.includes('<object name="test2"/>'), 'Expected object test2 in summary.xml');
+    done();
+  });
+  /**
    * Tests that the 'docs' command generates expected comments from XMIR to HTML.
    * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
    */


### PR DESCRIPTION
Fixes #467

Adds summary XML file generation to the `docs` command. After generating HTML documentation, the command now also produces a `summary.xml` file in `<eodoc>` format listing all packages and objects.

Changes:
- Add `xmlEscape()` helper for safe XML entity escaping
- Generate `summary.xml` with `<eodoc>` root, `<package>` and `<object>` children
- Include `packages` and `objects` count attributes on root element