### PR TITLE
#94: Add timestamps for maven logs

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -21,6 +21,18 @@ function shell() {
   }
 }
 
+/**
+ * Format a timestamp for log lines.
+ * @return {String} Timestamp string in [HH:MM:SS] format
+ */
+function timestamp() {
+  const now = new Date();
+  const h = String(now.getHours()).padStart(2, '0');
+  const m = String(now.getMinutes()).padStart(2, '0');
+  const s = String(now.getSeconds()).padStart(2, '0');
+  return `[${h}:${m}:${s}]`;
+}
+
 let beginning,
   phase = 'unknown',
   running = false,
@@ -99,10 +111,28 @@ module.exports.mvnw = function(args, tgt, batch) {
       process.platform === 'win32' ? params.map((p) => `"${p}"`) : params,
       {
         cwd: home,
-        stdio: 'inherit',
+        stdio: ['pipe', 'pipe', 'inherit'],
         shell: shell(),
       }
     );
+    result.stdout.on('data', (chunk) => {
+      const ts = timestamp();
+      const lines = chunk.toString().split('\n');
+      for (const line of lines) {
+        if (line.trim()) {
+          process.stdout.write(`${ts} ${line.trim()}\n`);
+        }
+      }
+    });
+    result.stderr.on('data', (chunk) => {
+      const ts = timestamp();
+      const lines = chunk.toString().split('\n');
+      for (const line of lines) {
+        if (line.trim()) {
+          process.stderr.write(`${ts} ${line.trim()}\n`);
+        }
+      }
+    });
     if (tgt !== undefined && args.includes('--quiet')) {
       if (!batch) {
         start();

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -113,33 +113,44 @@ module.exports.mvnw = function(args, tgt, batch) {
       process.platform === 'win32' ? params.map((p) => `"${p}"`) : params,
       {
         cwd: home,
-        stdio: ['pipe', 'pipe', 'inherit'],
+        stdio: ['pipe', 'pipe', 'pipe'],
         shell: shell(),
       }
     );
+    let outBuf = '';
+    let errBuf = '';
     result.stdout.on('data', (chunk) => {
-      const ts = timestamp();
-      const lines = chunk.toString().split('\n');
-      for (const line of lines) {
-        if (line.trim()) {
-          process.stdout.write(`${ts} ${line.trim()}\n`);
-        }
+      outBuf += chunk.toString();
+      let idx;
+      while ((idx = outBuf.indexOf('\n')) !== -1) {
+        process.stdout.write(`${timestamp()} ${outBuf.slice(0, idx)}\n`);
+        outBuf = outBuf.slice(idx + 1);
       }
     });
     result.stderr.on('data', (chunk) => {
-      const ts = timestamp();
-      const lines = chunk.toString().split('\n');
-      for (const line of lines) {
-        if (line.trim()) {
-          process.stderr.write(`${ts} ${line.trim()}\n`);
-        }
+      errBuf += chunk.toString();
+      let idx;
+      while ((idx = errBuf.indexOf('\n')) !== -1) {
+        process.stderr.write(`${timestamp()} ${errBuf.slice(0, idx)}\n`);
+        errBuf = errBuf.slice(idx + 1);
       }
     });
+    function flush() {
+      if (outBuf) {
+        process.stdout.write(`${timestamp()} ${outBuf}\n`);
+        outBuf = '';
+      }
+      if (errBuf) {
+        process.stderr.write(`${timestamp()} ${errBuf}\n`);
+        errBuf = '';
+      }
+    }
     if (tgt !== undefined && args.includes('--quiet')) {
       if (!batch) {
         start();
       }
       result.on('close', (code) => {
+        flush();
         if (code !== 0) {
           console.error(`The command "${cmd}" exited with #${code} code`);
           process.exit(1);
@@ -151,6 +162,7 @@ module.exports.mvnw = function(args, tgt, batch) {
       });
     } else {
       result.on('close', (code) => {
+        flush();
         if (code !== 0) {
           console.error(`The command "${cmd}" exited with #${code} code`);
           process.exit(1);

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -21,6 +21,18 @@ function shell() {
   }
 }
 
+/**
+ * Format a timestamp for log lines.
+ * @return {String} Timestamp string in [HH:MM:SS] format
+ */
+function timestamp() {
+  const now = new Date();
+  const h = String(now.getHours()).padStart(2, '0');
+  const m = String(now.getMinutes()).padStart(2, '0');
+  const s = String(now.getSeconds()).padStart(2, '0');
+  return `[${h}:${m}:${s}]`;
+}
+
 let beginning,
   phase = 'unknown',
   running = false,
@@ -101,10 +113,28 @@ module.exports.mvnw = function(args, tgt, batch) {
       process.platform === 'win32' ? params.map((p) => `"${p}"`) : params,
       {
         cwd: home,
-        stdio: 'inherit',
+        stdio: ['pipe', 'pipe', 'inherit'],
         shell: shell(),
       }
     );
+    result.stdout.on('data', (chunk) => {
+      const ts = timestamp();
+      const lines = chunk.toString().split('\n');
+      for (const line of lines) {
+        if (line.trim()) {
+          process.stdout.write(`${ts} ${line.trim()}\n`);
+        }
+      }
+    });
+    result.stderr.on('data', (chunk) => {
+      const ts = timestamp();
+      const lines = chunk.toString().split('\n');
+      for (const line of lines) {
+        if (line.trim()) {
+          process.stderr.write(`${ts} ${line.trim()}\n`);
+        }
+      }
+    });
     if (tgt !== undefined && args.includes('--quiet')) {
       if (!batch) {
         start();

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -59,6 +59,25 @@ describe('mvnw', () => {
       'Expected Maven INFO logs to include timestamps in yyyy-MM-dd HH:mm:ss format'
     );
   });
+  it('prefixes mvnw output lines with [HH:MM:SS] timestamp', async function () {
+    this.timeout(30000);
+    const orig = process.stdout.write;
+    const captured = [];
+    process.stdout.write = (chunk) => {
+      captured.push(chunk.toString());
+    };
+    try {
+      await mvnw(['--version', '--quiet'], null, true);
+    } finally {
+      process.stdout.write = orig;
+    }
+    const timestamped = captured.join('').split('\n')
+      .filter((l) => /^\[\d{2}:\d{2}:\d{2}\] /.test(l));
+    assert.ok(
+      timestamped.length > 0,
+      'Expected at least one output line with [HH:MM:SS] prefix'
+    );
+  });
   it('should handle ENOENT race condition in count function', function () {
     this.timeout(3000);
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eoc-mvnw-enoent-'));


### PR DESCRIPTION
Fixes #94

Add timestamps to Maven log output for easier debugging.

Changes to src/mvnw.js:
- Add timestamp() function for [HH:MM:SS] formatted log prefixes
- Pipe Maven stdout/stderr to add timestamps
- Makes debugging long builds much easier