### PR TITLE
fix(#94): add timestamps for maven logs

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -65,6 +65,8 @@ module.exports.flags = function(opts) {
     `-Deo.placedFormat=csv`,
     `-Deo.skipLinting=${opts.blind ? 'true' : 'false'}`,
     opts.trackTransformationSteps ? '-Deo.trackTransformationSteps' : '',
+    '-Dorg.slf4j.simpleLogger.showDateTime=true',
+    '-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss',
   ].filter(flag => flag !== '');
 };
 

--- a/test/commands/java/test_pipeline.js
+++ b/test/commands/java/test_pipeline.js
@@ -33,6 +33,8 @@ describe('java/pipeline', () => {
         `-Deo.placed=${path.resolve(opts.target, 'eo-placed.csv')}`,
         '-Deo.placedFormat=csv',
         '-Deo.skipLinting=false',
+        '-Dorg.slf4j.simpleLogger.showDateTime=true',
+        '-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss',
       ]
     );
   });

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -7,6 +7,7 @@ const {mvnw, flags} = require('../src/mvnw');
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const {execSync} = require('child_process');
 
 describe('mvnw', () => {
   it('prints Maven own version', async () => {
@@ -23,6 +24,39 @@ describe('mvnw', () => {
     const args = await mvnw(['--version', '--quiet', ...flags(opts)]);
     assert.ok(args.includes('-Deo.tag=homeTag'));
     assert.ok(args.includes('-Deo.version=0.28.11'));
+  });
+  it('includes slf4j-simple timestamp flags', () => {
+    const opts = {
+      sources: 'sources',
+      target: 'target',
+    };
+    const result = flags(opts);
+    assert.ok(
+      result.includes('-Dorg.slf4j.simpleLogger.showDateTime=true'),
+      'Expected slf4j showDateTime flag'
+    );
+    assert.ok(
+      result.includes('-Dorg.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss'),
+      'Expected slf4j dateTimeFormat flag'
+    );
+  });
+  it('shows timestamps in Maven log output', function () {
+    this.timeout(60000);
+    const home = path.resolve('temp/test-mvnw-timestamp');
+    fs.rmSync(home, {recursive: true, force: true});
+    fs.mkdirSync(path.resolve(home, 'src'), {recursive: true});
+    fs.writeFileSync(
+      path.resolve(home, 'src/simple.eo'),
+      '# sample\n[] > simple\n'
+    );
+    const combined = execSync(
+      `node ${path.resolve('./src/eoc.js')} parse --verbose -s ${path.resolve(home, 'src')} -t ${path.resolve(home, 'target')} 2>&1`,
+      {timeout: 300000, windowsHide: true}
+    ).toString();
+    assert.ok(
+      /\d{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12]\d|3[01]) \d{2}:\d{2}:\d{2} \[INFO\]/.test(combined),
+      'Expected Maven INFO logs to include timestamps in yyyy-MM-dd HH:mm:ss format'
+    );
   });
   it('should handle ENOENT race condition in count function', function (done) {
     this.timeout(3000);


### PR DESCRIPTION
## Summary

- Add `slf4j-simple` JVM flags to every Maven invocation to enable timestamps in build logs
- Two flags added: `showDateTime=true` and `dateTimeFormat=yyyy-MM-dd HH:mm:ss`
- ISO date format used (issue originally specified `yyyy-dd-MM` which would swap month and day)

## Test plan

- [x] Unit test: verifies slf4j flags appear in `flags()` output (`test/test_mvnw.js`)
- [x] Integration test: runs `eoc parse --verbose` and asserts `[INFO]` lines include valid timestamps (`test/test_mvnw.js`)
- [x] Pipeline test: updated expected command array (`test/commands/java/test_pipeline.js`)
- [x] `npx eslint` passes
- [x] All mocha tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)