### PR TITLE
fix(#966): format relative sources in place

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -372,7 +372,7 @@ program.command('fmt')
     await pipe()(coms(), ['register', 'parse'], program.opts());
     await coms().print({
       printInput: '1-parse',
-      printOutput: program.opts().sources,
+      printOutput: path.resolve(program.opts().sources),
       ...program.opts()
     });
   });

--- a/test/commands/test_fmt.js
+++ b/test/commands/test_fmt.js
@@ -148,4 +148,20 @@ describe('fmt', () => {
     })
     done()
   })
+  it('formats relative sources in place without writing under target', done => {
+    const [source, target] = prepareTestDirectory()
+    const file = createFile(source, testCases[0].before)
+    const relativeSource = path.relative(process.cwd(), source)
+    fmt(relativeSource, target)
+    assert.strictEqual(
+      fs.readFileSync(file, 'utf8'),
+      testCases[0].after,
+      'Relative --sources must be overwritten in place'
+    )
+    assert(
+      !fs.existsSync(path.resolve(target, relativeSource, 'app.eo')),
+      'Relative --sources must not create formatted files under --target'
+    )
+    done()
+  })
 })


### PR DESCRIPTION
## What changed

`eoc fmt` now passes the source directory to `print` as an absolute path. This keeps the existing standalone `print` behavior, where `--print-output` is relative to `--target`, but prevents the `fmt` wrapper from treating a relative `--sources` value as a target-relative output directory.

I also added a regression test for relative `--sources`: it verifies the original source file is formatted in place and that no mirrored output is created under `--target/<relative-sources>`.

Closes #966.

## Verification

- `npm ci`
- `npx mocha test/commands/test_fmt.js --timeout 1200000`
- `npx eslint src/eoc.js test/commands/test_fmt.js`
- `node --check src/eoc.js`
- `node --check test/commands/test_fmt.js`
- `git diff --check`
