### PR TITLE
Remove duplicate invalid parser-version test in test_parse.js

### DIFF
--- a/test/commands/test_parse.js
+++ b/test/commands/test_parse.js
@@ -44,15 +44,14 @@ describe('parse', () => {
     const home = path.resolve('temp/test-parse/invalid-version');
     createTestProject(home);
     assert.throws(
-      () => {
-        runSync([
-          'parse',
-          '--parser=999.999.999',
-          '-s', path.resolve(home, 'src'),
-          '-t', path.resolve(home, 'target'),
-        ]);
-      },
-      'Command should fail with invalid parser version'
+      () => runSync([
+        'parse',
+        '--parser=999.999.999',
+        '-s', path.resolve(home, 'src'),
+        '-t', path.resolve(home, 'target'),
+      ]),
+      (error) => error.status === 1,
+      'invalid parser version was not rejected with a non-zero exit'
     );
   });
   it('accepts valid parser version', function () {
@@ -66,20 +65,19 @@ describe('parse', () => {
       '-t', path.resolve(home, 'target'),
     ]);
   });
-  it('validates parser version before calling Maven', function () {
+  it('rejects a malformed parser version', function () {
     this.timeout(30000);
-    const home = path.resolve('temp/test-parse/early-validation');
+    const home = path.resolve('temp/test-parse/malformed-version');
     createTestProject(home);
     assert.throws(
-      () => {
-        runSync([
-          'parse',
-          '--parser=999.999.999',
-          '-s', path.resolve(home, 'src'),
-          '-t', path.resolve(home, 'target'),
-        ]);
-      },
-      'Command should fail with invalid version'
+      () => runSync([
+        'parse',
+        '--parser=not-a-version',
+        '-s', path.resolve(home, 'src'),
+        '-t', path.resolve(home, 'target'),
+      ]),
+      (error) => error.status === 1,
+      'malformed parser version was not rejected with a non-zero exit'
     );
   });
   it('handles assemble command with invalid version', function () {
@@ -87,15 +85,14 @@ describe('parse', () => {
     const home = path.resolve('temp/test-parse/assemble-invalid');
     createTestProject(home);
     assert.throws(
-      () => {
-        runSync([
-          'assemble',
-          '--parser=999.999.999',
-          '-s', path.resolve(home, 'src'),
-          '-t', path.resolve(home, 'target'),
-        ]);
-      },
-      'Assemble should fail with invalid version'
+      () => runSync([
+        'assemble',
+        '--parser=999.999.999',
+        '-s', path.resolve(home, 'src'),
+        '-t', path.resolve(home, 'target'),
+      ]),
+      (error) => error.status === 1,
+      'assemble with an invalid parser version was not rejected with a non-zero exit'
     );
   });
   it('handles lint command with invalid version', function () {
@@ -103,15 +100,14 @@ describe('parse', () => {
     const home = path.resolve('temp/test-parse/lint-invalid');
     createTestProject(home);
     assert.throws(
-      () => {
-        runSync([
-          'lint',
-          '--parser=999.999.999',
-          '-s', path.resolve(home, 'src'),
-          '-t', path.resolve(home, 'target'),
-        ]);
-      },
-      'Lint should fail with invalid version'
+      () => runSync([
+        'lint',
+        '--parser=999.999.999',
+        '-s', path.resolve(home, 'src'),
+        '-t', path.resolve(home, 'target'),
+      ]),
+      (error) => error.status === 1,
+      'lint with an invalid parser version was not rejected with a non-zero exit'
     );
   });
 });


### PR DESCRIPTION
The cases `rejects invalid parser version` and `validates parser version before calling Maven` ran the same command (`parse --parser=999.999.999`) with the same `assert.throws`, differing only in the temp-directory name and the string handed to `assert.throws`. That string was read as the no-throw message rather than a matcher, so neither case checked how the command actually failed. This drops the duplicate and makes the surviving case verify a real signal: the run must exit with status 1.

In place of the duplicate I added a separate case for a malformed version (`--parser=not-a-version`), so the suite now covers two kinds of bad input instead of the same one twice. I did look at making the second case assert that no Maven artifacts land under `target`, to prove the early guard in `src/mvnw.js` rejects the version before Maven runs. That does not work: a bogus version that reaches Maven also fails with exit 1 and leaves no `target`, so the absence of artifacts distinguishes nothing. The only thing that separates the early guard from a late Maven failure is the console line, which we do not assert on, so removing the duplicate is the right call.

Closes #972
