### PR TITLE
fix: declare test helper variables

### DIFF
--- a/test/commands/java/test_pipeline.js
+++ b/test/commands/java/test_pipeline.js
@@ -12,12 +12,12 @@ describe('java/pipeline', () => {
       register: {goals: () => ['eo:register']},
       assemble: {goals: () => ['eo:assemble']},
     };
-    calls = [];
+    const calls = [];
     const maven = function maven(command) {
       calls.push(command);
-    }
-    opts = {sources: 'sources-dir', target: 'target-dir'};
-    await pipeline(coms, ['register', 'assemble'], opts, maven)
+    };
+    const opts = {sources: 'sources-dir', target: 'target-dir'};
+    await pipeline(coms, ['register', 'assemble'], opts, maven);
     assert.deepStrictEqual(
       calls[0],
       [
@@ -43,17 +43,17 @@ describe('java/pipeline', () => {
         extras: (opts) => [`-Deo.failOnWarning=${opts.easy ? 'false' : 'true'}`],
       },
     };
-    calls = [];
+    const calls = [];
     const maven = function maven(command) {
       calls.push(command);
-    }
-    opts = {
+    };
+    const opts = {
       sources: 'lint-sources-dir',
       target: 'lint-target-dir',
       newParser: true,
       easy: true,
     };
-    await pipeline(coms, ['lint'], opts, maven)
+    await pipeline(coms, ['lint'], opts, maven);
     assert(calls[0].includes('eo:lint'));
     assert(calls[0].includes('-Deo.failOnWarning=false'));
   });
@@ -61,12 +61,16 @@ describe('java/pipeline', () => {
     const coms = {
       resolve: {goals: () => ['eo:resolve', 'eo:place']},
     };
-    calls = [];
+    const calls = [];
     const maven = function maven(command) {
       calls.push(command);
-    }
-    await pipeline(coms, ['resolve'], {sources: 'srs', target: 'tgt'}, maven)
+    };
+    await pipeline(coms, ['resolve'], {sources: 'srs', target: 'tgt'}, maven);
     assert(calls[0].includes('eo:resolve'));
     assert(calls[0].includes('eo:place'));
+  });
+  it('does not leak helper variables into global scope', () => {
+    assert.strictEqual(globalThis.calls, undefined);
+    assert.strictEqual(globalThis.opts, undefined);
   });
 });

--- a/test/commands/test_generate_comments.js
+++ b/test/commands/test_generate_comments.js
@@ -23,7 +23,7 @@ describe('generate_comments', () => {
   });
   it('fills output depending on the number of placeholders in the input code', (done) => {
     const home = makeHome();
-    for (numberOfPlaceholders = 0; numberOfPlaceholders < 3; ++numberOfPlaceholders) {
+    for (let numberOfPlaceholders = 0; numberOfPlaceholders < 3; ++numberOfPlaceholders) {
       const exampleInput =
         '# <COMMENT-TO-BE-ADDED>\n'.repeat(numberOfPlaceholders);
       const outputFilePath = path.resolve(home, 'out.json');
@@ -40,7 +40,7 @@ describe('generate_comments', () => {
   });
   it('fills output as expected when encountering valid EO code', (done) => {
     const home = makeHome();
-    for (numberOfPlaceholders = 0; numberOfPlaceholders < 3; ++numberOfPlaceholders) {
+    for (let numberOfPlaceholders = 0; numberOfPlaceholders < 3; ++numberOfPlaceholders) {
       const exampleInput = [
         '# <STRUCTURE-BELOW-IS-TO-BE-DOCUMENTED>',
         '[args] > simple',
@@ -64,6 +64,9 @@ describe('generate_comments', () => {
       verifyGeneratedOutput(stdout, home, outputFilePath, expectedContents);
     }
     done();
+  });
+  it('does not leak placeholder counters into global scope', () => {
+    assert.strictEqual(globalThis.numberOfPlaceholders, undefined);
   });
 });
 


### PR DESCRIPTION
## Summary
- Declare `calls` and `opts` inside `test/commands/java/test_pipeline.js` tests instead of leaking globals.
- Declare `numberOfPlaceholders` inside the `generate_comments` loops.
- Add regression checks proving the helpers no longer land on `globalThis`.

Closes #969

## Tests
- `node ..\objectionary__eoc_fix\node_modules\mocha\bin\mocha.js test\commands\java\test_pipeline.js --timeout 1200000`
- `node ..\objectionary__eoc_fix\node_modules\mocha\bin\mocha.js test\commands\test_generate_comments.js --grep "does not leak placeholder" --timeout 1200000`
- `node ..\objectionary__eoc_fix\node_modules\eslint\bin\eslint.js test\commands\java\test_pipeline.js test\commands\test_generate_comments.js`
- `git diff --check origin/master...HEAD`

Note: full `test/commands/test_generate_comments.js` is not runnable in this local Windows shell because its helper spawns bare `node` via `execSync`, and that child command is not found in this environment. The new leak regression itself was run and passes.

Prepared with local automation assistance and reviewed before submission.