### PR TITLE
test: remove redundant mvnw catch

### DIFF
--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -37,17 +37,10 @@ describe('mvnw', () => {
       if (fs.existsSync(dir)) {
         for (const f of fs.readdirSync(dir)) {
           const next = path.join(dir, f);
-          try {
-            if (fs.statSync(next).isDirectory()) {
-              curr = count(next, curr);
-            } else {
-              curr++;
-            }
-          } catch (error) {
-            if (error.code === 'ENOENT') {
-              throw error;
-            }
-            throw error;
+          if (fs.statSync(next).isDirectory()) {
+            curr = count(next, curr);
+          } else {
+            curr++;
           }
         }
       }


### PR DESCRIPTION
## Summary
- Remove the redundant local `count` try/catch in `test/test_mvnw.js`.
- Keep the test behavior unchanged while dropping the dead ENOENT branch.

Closes #970

## Tests
- `node ..\objectionary__eoc_fix\node_modules\mocha\bin\mocha.js test\test_mvnw.js --grep "ENOENT race" --timeout 1200000`
- `node ..\objectionary__eoc_fix\node_modules\eslint\bin\eslint.js test\test_mvnw.js`
- `git diff --check`
- `git merge-tree --write-tree origin/master HEAD`

Prepared with local automation assistance and reviewed before submission.