### PR TITLE
test: check parser validation output

### DIFF
--- a/test/commands/test_parse.js
+++ b/test/commands/test_parse.js
@@ -70,16 +70,28 @@ describe('parse', () => {
     this.timeout(30000);
     const home = path.resolve('temp/test-parse/early-validation');
     createTestProject(home);
-    assert.throws(
-      () => {
-        runSync([
-          'parse',
-          '--parser=999.999.999',
-          '-s', path.resolve(home, 'src'),
-          '-t', path.resolve(home, 'target'),
-        ]);
-      },
-      'Command should fail with invalid version'
+    let error;
+    try {
+      runSync([
+        'parse',
+        '--parser=999.999.999',
+        '-s', path.resolve(home, 'src'),
+        '-t', path.resolve(home, 'target'),
+      ]);
+    } catch (caught) {
+      error = caught;
+    }
+    assert(error, 'Command should fail with invalid version');
+    assert(
+      error.stderr.toString().includes(
+        'Parser version 999.999.999 is not available in Maven Central.'
+      ),
+      error.stderr.toString()
+    );
+    assert.strictEqual(
+      fs.existsSync(path.resolve(home, 'target')),
+      false,
+      'Maven target directory should not be created after early parser validation'
     );
   });
   it('handles assemble command with invalid version', function () {


### PR DESCRIPTION
## Summary
- Make the early parser-version validation test assert the specific validation output instead of duplicating the generic invalid-version test.
- Assert that the Maven target directory is not created after the early parser validation failure.

Closes #972

## Tests
- `node` bootstrap + Mocha: `test/commands/test_parse.js --grep 'validates parser version'` -> 1 passing
- `node ..\objectionary__eoc_fix\node_modules\eslint\bin\eslint.js test\commands\test_parse.js` with shared `NODE_PATH` -> passed
- `git diff --check` -> passed
- `git merge-tree --write-tree origin/master HEAD` -> passed