### PR TITLE
fix(#971): make parser-version URL and network-error tests assert real behavior

### DIFF
--- a/src/parser-version.js
+++ b/src/parser-version.js
@@ -27,18 +27,26 @@ const request = require('sync-request'),
       return version.value;
     },
     /**
+     * Build the Maven Central URL of a parser version POM.
+     * @param {String} ver - Version to locate, for example '0.23.1'
+     * @return {String} Full URL of the eo-maven-plugin POM
+     */
+    url(ver) {
+      const repo = 'org/eolang/eo-maven-plugin',
+        artifactId = 'eo-maven-plugin';
+      return `https://repo.maven.apache.org/maven2/${repo}/${ver}/${artifactId}-${ver}.pom`;
+    },
+    /**
      * Check if a specific parser version exists in Maven Central.
      * @param {String} ver - Version to check, for example '0.23.1'
+     * @param {function} fetch - HTTP call, defaults to sync-request
      * @return {Boolean} True if version exists, false otherwise
      */
-    exists(ver) {
+    exists(ver, fetch = request) {
       let result;
       if (ver && ver !== 'undefined') {
         try {
-          const repo = 'org/eolang/eo-maven-plugin',
-            artifactId = 'eo-maven-plugin',
-            url = `https://repo.maven.apache.org/maven2/${repo}/${ver}/${artifactId}-${ver}.pom`,
-            res = request('GET', url, {timeout: 10000, socketTimeout: 10000});
+          const res = fetch('GET', version.url(ver), {timeout: 10000, socketTimeout: 10000});
           result = res.statusCode === 200;
         } catch (e) {
           console.debug('Unable to validate parser version (network error): %s', e.message);

--- a/test/test_parser_version.js
+++ b/test/test_parser_version.js
@@ -60,16 +60,23 @@ describe('parser-version', () => {
       const exists = parserVersion.exists('undefined');
       assert.strictEqual(exists, false, 'String "undefined" should return false');
     });
-    it('constructs correct Maven Central URL', function () {
-      this.timeout(15000);
-      const exists = parserVersion.exists('0.28.11');
-      assert.strictEqual(exists, true, 'URL should be correctly formatted to find version 0.28.11');
+    it('constructs correct Maven Central URL', () => {
+      const url = parserVersion.url('0.28.11');
+      assert.strictEqual(
+        url,
+        'https://repo.maven.apache.org/maven2/org/eolang/eo-maven-plugin/0.28.11/eo-maven-plugin-0.28.11.pom',
+        `URL ${url} should point to the eo-maven-plugin POM of 0.28.11`
+      );
     });
-    it('handles network errors gracefully', function () {
-      this.timeout(15000);
-      assert.doesNotThrow(() => {
-        parserVersion.exists('0.28.11');
+    it('returns false when the HTTP call throws', () => {
+      const exists = parserVersion.exists('0.28.11', () => {
+        throw new Error('connection refused');
       });
+      assert.strictEqual(exists, false, 'A failing HTTP call should make exists return false');
+    });
+    it('returns false when the HTTP status is not 200', () => {
+      const exists = parserVersion.exists('0.28.11', () => ({statusCode: 404}));
+      assert.strictEqual(exists, false, 'A non-200 response should make exists return false');
     });
   });
 });


### PR DESCRIPTION
The `exists()` suite in `test/test_parser_version.js` had two cases that promised something their assertions never checked. "constructs correct Maven Central URL" was a verbatim copy of the plain valid-version test: it called `exists('0.28.11')` and asserted the result was `true`, never once looking at the URL. "handles network errors gracefully" wrapped the same happy-path call in `assert.doesNotThrow`, but the describe block gates on connectivity, so the call always took the 200 branch — and `exists` already swallows exceptions internally, so the assertion could not fail for any input. Both were green regardless of whether the URL or the catch branch actually worked.

To make them real, `parser-version.js` now exposes a small `url(ver)` method, and `exists(ver, fetch)` accepts an injected HTTP call that defaults to `sync-request`. The URL test asserts the exact path the code builds, with no network involved. The network-error test injects a fetch that throws and asserts `exists` returns `false`, which finally drives the `catch` branch. A third case injects a non-200 response to cover that branch deterministically too.

Closes #971
