### PR TITLE
fix(#969): declare test helper variables so they dont leak onto globalThis

### DIFF
--- a/test/commands/java/test_pipeline.js
+++ b/test/commands/java/test_pipeline.js
@@ -12,11 +12,11 @@ describe('java/pipeline', () => {
       register: {goals: () => ['eo:register']},
       assemble: {goals: () => ['eo:assemble']},
     };
-    calls = [];
+    const calls = [];
     const maven = function maven(command) {
       calls.push(command);
     }
-    opts = {sources: 'sources-dir', target: 'target-dir'};
+    const opts = {sources: 'sources-dir', target: 'target-dir'};
     await pipeline(coms, ['register', 'assemble'], opts, maven)
     assert.deepStrictEqual(
       calls[0],
@@ -45,11 +45,11 @@ describe('java/pipeline', () => {
         extras: (opts) => [`-Deo.failOnWarning=${opts.easy ? 'false' : 'true'}`],
       },
     };
-    calls = [];
+    const calls = [];
     const maven = function maven(command) {
       calls.push(command);
     }
-    opts = {
+    const opts = {
       sources: 'lint-sources-dir',
       target: 'lint-target-dir',
       newParser: true,
@@ -63,12 +63,15 @@ describe('java/pipeline', () => {
     const coms = {
       resolve: {goals: () => ['eo:resolve', 'eo:place']},
     };
-    calls = [];
+    const calls = [];
     const maven = function maven(command) {
       calls.push(command);
     }
     await pipeline(coms, ['resolve'], {sources: 'srs', target: 'tgt'}, maven)
     assert(calls[0].includes('eo:resolve'));
     assert(calls[0].includes('eo:place'));
+  });
+  it('does not leak the maven accumulator into the global scope', () => {
+    assert.strictEqual(globalThis.calls, undefined, 'calls leaked onto the global object');
   });
 });

--- a/test/commands/java/test_pipeline.js
+++ b/test/commands/java/test_pipeline.js
@@ -74,4 +74,18 @@ describe('java/pipeline', () => {
   it('does not leak the maven accumulator into the global scope', () => {
     assert.strictEqual(globalThis.calls, undefined, 'calls leaked onto the global object');
   });
+  it('does not leak the pipeline options into the global scope', () => {
+    assert.strictEqual(globalThis.opts, undefined, 'opts leaked onto the global object');
+  });
+  it('starts every run with an isolated accumulator', async () => {
+    const coms = {
+      register: {goals: () => ['eo:register']},
+    };
+    const calls = [];
+    const maven = function maven(command) {
+      calls.push(command);
+    }
+    await pipeline(coms, ['register'], {sources: 'iso-srs', target: 'iso-tgt'}, maven)
+    assert.strictEqual(calls.length, 1, 'accumulator carried commands from another run');
+  });
 });

--- a/test/commands/test_generate_comments.js
+++ b/test/commands/test_generate_comments.js
@@ -65,6 +65,18 @@ describe('generate_comments', () => {
     }
     done();
   });
+  it('produces empty output when the source carries no placeholder', (done) => {
+    const home = makeHome();
+    const outputFilePath = path.resolve(home, 'out.json');
+    const stdout = runSync([
+      'generate_comments',
+      '--provider=placeholder',
+      `--prompt_template=${makePromptFile(home, '')}`,
+      `--source=${makeInputFile(home, '[args] > app')}`,
+      `--output=${outputFilePath}`]);
+    verifyGeneratedOutput(stdout, home, outputFilePath, []);
+    done();
+  });
   it('does not leak the placeholders counter into the global scope', () => {
     assert.strictEqual(globalThis.placeholders, undefined, 'placeholders leaked onto the global object');
   });

--- a/test/commands/test_generate_comments.js
+++ b/test/commands/test_generate_comments.js
@@ -23,9 +23,9 @@ describe('generate_comments', () => {
   });
   it('fills output depending on the number of placeholders in the input code', (done) => {
     const home = makeHome();
-    for (numberOfPlaceholders = 0; numberOfPlaceholders < 3; ++numberOfPlaceholders) {
+    for (let placeholders = 0; placeholders < 3; ++placeholders) {
       const exampleInput =
-        '# <COMMENT-TO-BE-ADDED>\n'.repeat(numberOfPlaceholders);
+        '# <COMMENT-TO-BE-ADDED>\n'.repeat(placeholders);
       const outputFilePath = path.resolve(home, 'out.json');
       const stdout = runSync([
         'generate_comments',
@@ -33,14 +33,14 @@ describe('generate_comments', () => {
         `--prompt_template=${makePromptFile(home, '')}`,
         `--source=${makeInputFile(home, exampleInput)}`,
         `--output=${outputFilePath}`]);
-      const expectedContents = Array(numberOfPlaceholders).fill('<PLACEHOLDER_RESPONSE>');
+      const expectedContents = Array(placeholders).fill('<PLACEHOLDER_RESPONSE>');
       verifyGeneratedOutput(stdout, home, outputFilePath, expectedContents);
     }
     done();
   });
   it('fills output as expected when encountering valid EO code', (done) => {
     const home = makeHome();
-    for (numberOfPlaceholders = 0; numberOfPlaceholders < 3; ++numberOfPlaceholders) {
+    for (let placeholders = 0; placeholders < 3; ++placeholders) {
       const exampleInput = [
         '# <STRUCTURE-BELOW-IS-TO-BE-DOCUMENTED>',
         '[args] > simple',
@@ -64,6 +64,9 @@ describe('generate_comments', () => {
       verifyGeneratedOutput(stdout, home, outputFilePath, expectedContents);
     }
     done();
+  });
+  it('does not leak the placeholders counter into the global scope', () => {
+    assert.strictEqual(globalThis.placeholders, undefined, 'placeholders leaked onto the global object');
   });
 });
 


### PR DESCRIPTION
The helper variables in two test files were assigned without a declaration, so each bare assignment landed on `globalThis` instead of staying local. The three `java/pipeline` tests shared one `calls` array through the global object, and the `generate_comments` loops did the same with their counter. They passed only because every test reset the value at its top; the moment a test forgot to reset, or the file gained `'use strict'`, the behaviour would change or throw.

This declares each one in place: `const calls` and `const opts` in `test/commands/java/test_pipeline.js`, and `let placeholders` in the two loops of `test/commands/test_generate_comments.js`. The counter is also renamed from `numberOfPlaceholders` to keep it within the two-word limit. Two guards assert the globals stay clean between tests, so the leak cannot creep back.

Closes #969
