### PR TITLE
fix(#1009): skip Maven Central check for SNAPSHOT parser versions

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -42,7 +42,7 @@ module.exports.flags = function(opts) {
   console.debug('Sources in %s', rel(sources));
   const target = path.resolve(opts.target);
   console.debug('Target in %s', rel(target));
-  if (opts.parser && !parserVersion.exists(opts.parser)) {
+  if (opts.parser && !opts.parser.endsWith('-SNAPSHOT') && !parserVersion.exists(opts.parser)) {
     console.error(colors.red(
       `Parser version ${opts.parser} is not available in Maven Central.\n` +
       `Please check available versions at: https://repo.maven.apache.org/maven2/org/eolang/eo-maven-plugin/\n` +

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -59,6 +59,16 @@ describe('mvnw', () => {
       'Expected Maven INFO logs to include timestamps in yyyy-MM-dd HH:mm:ss format'
     );
   });
+  it('skips the Maven Central check for SNAPSHOT parser versions', () => {
+    const opts = {
+      sources: 'sources',
+      target: 'target',
+      parser: '1.0-SNAPSHOT',
+      homeTag: 'homeTag'
+    };
+    const result = flags(opts);
+    assert.ok(result.includes('-Deo.version=1.0-SNAPSHOT'));
+  });
   it('should handle ENOENT race condition in count function', function () {
     this.timeout(3000);
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eoc-mvnw-enoent-'));


### PR DESCRIPTION
Skip Maven Central check for `-SNAPSHOT` parser versions.

Fixes #1009