### PR TITLE
Split fmt test into independent per-case tests

### DIFF
--- a/test/commands/test_fmt.js
+++ b/test/commands/test_fmt.js
@@ -10,10 +10,11 @@ const { runSync, parserVersion, homeTag, weAreOnline } = require('../helpers')
 
 /**
  * Prepare test directory and return the home path
+ * @param {string} name - Unique sub-directory name for this case
  * @return {Array} Array containing source and target directory paths
  */
-function prepareTestDirectory () {
-  const home = path.resolve('temp/test-fmt/simple')
+function prepareTestDirectory (name) {
+  const home = path.resolve('temp/test-fmt', name)
   const source = path.resolve(home, 'src')
   const target = path.resolve(home, 'target')
   fs.rmSync(home, { recursive: true, force: true })
@@ -59,6 +60,7 @@ function fmt (source, target) {
  */
 const testCases = [
   {
+    name: 'removes redundant comments from a bare object',
     before: [
       '# EO file header',
       '# Copyright notice for testing',
@@ -73,6 +75,7 @@ const testCases = [
     ].join('\n')
   },
   {
+    name: 'expands a single alias to fully qualified form',
     before: [
       '+alias math math',
       '# Calculator app',
@@ -91,6 +94,7 @@ const testCases = [
     ].join('\n')
   },
   {
+    name: 'expands stdout alias and qualifies its usage',
     before: [
       '+alias stdout io.stdout',
       '# Application entry point',
@@ -106,6 +110,7 @@ const testCases = [
     ].join('\n')
   },
   {
+    name: 'expands multiple aliases with nested arguments',
     before: [
       '+alias stdout io.stdout',
       '+alias sprintf tt.sprintf',
@@ -130,26 +135,21 @@ const testCases = [
 
 describe('fmt', () => {
   before(weAreOnline)
-  it('formats EO files according to expected patterns', done => {
-    const [source, target] = prepareTestDirectory()
-    testCases.forEach((testCase, index) => {
+  testCases.forEach((testCase, index) => {
+    it(testCase.name, done => {
+      const [source, target] = prepareTestDirectory(`case-${index}`)
       const file = createFile(source, testCase.before)
       fmt(source, target)
-      const formatted = fs.readFileSync(file, 'utf8')
       assert.strictEqual(
-        formatted,
+        fs.readFileSync(file, 'utf8'),
         testCase.after,
-        `Test case ${index} failed: formatting result doesn't match expected output`
+        `${testCase.name}: formatting result doesn't match expected output`
       )
-      assert(
-        formatted !== testCase.before,
-        `Test case ${index} failed: file should be different after formatting`
-      )
+      done()
     })
-    done()
   })
   it('formats relative sources in place without writing under target', done => {
-    const [source, target] = prepareTestDirectory()
+    const [source, target] = prepareTestDirectory('relative')
     const file = createFile(source, testCases[0].before)
     const relativeSource = path.relative(process.cwd(), source)
     fmt(relativeSource, target)
@@ -161,6 +161,18 @@ describe('fmt', () => {
     assert(
       !fs.existsSync(path.resolve(target, relativeSource, 'app.eo')),
       'Relative --sources must not create formatted files under --target'
+    )
+    done()
+  })
+  it('keeps an already formatted file unchanged on a second run', done => {
+    const [source, target] = prepareTestDirectory('idempotent')
+    const file = createFile(source, testCases[0].before)
+    fmt(source, target)
+    fmt(source, target)
+    assert.strictEqual(
+      fs.readFileSync(file, 'utf8'),
+      testCases[0].after,
+      'Formatting an already formatted file must be idempotent'
     )
     done()
   })


### PR DESCRIPTION
The `fmt` formatting test packed four separate format scenarios into a single `it()` that looped over the cases. Each iteration spawns a cold Maven JVM and runs the whole pipeline, so four full builds ran serialized inside one test, reusing the same `temp/test-fmt/simple` directory and carrying eight assertions. When an early case failed the rest never ran, and a hand-written `Test case N failed` message stood in for a real per-case name.

This splits the data table into one named `it()` per case, each with its own isolated temp directory. Failures no longer cascade, every scenario reports under its own sentence, and the cases are independent units that a parallel runner can schedule on their own.

I also added an idempotency edge case: formatting an already-formatted file a second time must leave it unchanged.

Closes #992
