### PR TITLE
Reject in mvnw on non-zero Maven exit instead of killing the process

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -378,13 +378,7 @@ program.command('fmt')
   });
 
 if (require.main === module) {
-  try {
-    program.parse(process.argv);
-  } catch (e) {
-    console.error(e.message);
-    console.debug(e.stack);
-    process.exit(1);
-  }
+  program.parseAsync(process.argv);
 }
 
 module.exports.commandsDescription = function commandsDescription() {

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -110,20 +110,20 @@ module.exports.mvnw = function(args, tgt, batch) {
         start();
       }
       result.on('close', (code) => {
-        if (code !== 0) {
-          console.error(`The command "${cmd}" exited with #${code} code`);
-          process.exit(1);
-        }
         if (!batch) {
           stop();
+        }
+        if (code !== 0) {
+          reject(new Error(`The command "${cmd}" exited with #${code} code`));
+          return;
         }
         resolve(args);
       });
     } else {
       result.on('close', (code) => {
         if (code !== 0) {
-          console.error(`The command "${cmd}" exited with #${code} code`);
-          process.exit(1);
+          reject(new Error(`The command "${cmd}" exited with #${code} code`));
+          return;
         }
         resolve(args);
       });

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -69,6 +69,36 @@ describe('mvnw', () => {
     const result = flags(opts);
     assert.ok(result.includes('-Deo.version=1.0-SNAPSHOT'));
   });
+  it('rejects when a quiet Maven run exits with a non-zero code', async function () {
+    this.timeout(60000);
+    await assert.rejects(
+      mvnw(['--unrecognized-eoc-flag', '--quiet'], null, true),
+      /exited with/,
+      'mvnw should reject instead of killing the process when a quiet run fails'
+    );
+  });
+  it('rejects when a verbose Maven run exits with a non-zero code', async function () {
+    this.timeout(60000);
+    await assert.rejects(
+      mvnw(['--unrecognized-eoc-flag'], undefined, true),
+      /exited with/,
+      'mvnw should reject instead of killing the process when a verbose run fails'
+    );
+  });
+  it('rejects with an Error so callers can wrap it as a cause', async function () {
+    this.timeout(60000);
+    await assert.rejects(
+      mvnw(['--unrecognized-eoc-flag'], undefined, true),
+      (error) => error instanceof Error,
+      'mvnw rejection is not a proper Error, callers cannot wrap it as a cause'
+    );
+  });
+  it('runs again after a previous run failed', async function () {
+    this.timeout(120000);
+    await assert.rejects(mvnw(['--unrecognized-eoc-flag', '--quiet'], null, true));
+    const args = await mvnw(['--version', '--quiet'], null, true);
+    assert.ok(args.includes('--version'), 'mvnw cannot run again, the process did not survive a failed run');
+  });
   it('should handle ENOENT race condition in count function', function () {
     this.timeout(3000);
     const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eoc-mvnw-enoent-'));


### PR DESCRIPTION
When `eoc lint` found problems, `mvnw()` terminated the whole process with `process.exit(1)` the moment Maven returned a non-zero code. The returned promise was never rejected, so the `catch` blocks in the lint command never ran. Users only ever saw Maven's raw exit-code line and were never told about the `--easy` flag.

Now `mvnw()` rejects with an `Error` carrying the exit-code context, so command-level `catch` blocks can add their guidance (the `--easy` hint) before the process ends. In the quiet path the progress spinner is stopped first so it does not keep printing after a failure.

Since the command actions are async, `eoc.js` switches to `parseAsync`. We deliberately rely on the native Node.js handling here rather than a manual `catch`: an unhandled rejection from `parseAsync` is escalated by Node's default `--unhandled-rejections=throw` mode, which prints the error message and exits with a non-zero code. This keeps the entry point a clean one-liner while still surfacing the error to the user.

Four tests cover the new behaviour: quiet and verbose runs both reject instead of tearing down the test process, the rejection is a real `Error` that callers can wrap as a cause, and `mvnw` can run again after a previous run failed.

Closes #999