### PR TITLE
Skip parser version check on network errors instead of a false-negative absence

### DIFF
--- a/src/parser-version.js
+++ b/src/parser-version.js
@@ -4,6 +4,7 @@
  */
 
 const {XMLParser} = require('fast-xml-parser');
+const colors = require('colors');
 const request = require('sync-request'),
 
   /**
@@ -40,7 +41,7 @@ const request = require('sync-request'),
      * Check if a specific parser version exists in Maven Central.
      * @param {String} ver - Version to check, for example '0.23.1'
      * @param {function} fetch - HTTP call, defaults to sync-request
-     * @return {Boolean} True if version exists, false otherwise
+     * @return {Boolean} True if version exists or cannot be verified, false if confirmed absent
      */
     exists(ver, fetch = request) {
       let result;
@@ -49,8 +50,10 @@ const request = require('sync-request'),
           const res = fetch('GET', version.url(ver), {timeout: 10000, socketTimeout: 10000});
           result = res.statusCode === 200;
         } catch (e) {
-          console.debug('Unable to validate parser version (network error): %s', e.message);
-          result = false;
+          console.warn(colors.yellow(
+            `Cannot verify parser version ${ver} in Maven Central (${e.message}), proceeding anyway`
+          ));
+          result = true;
         }
       } else {
         result = false;

--- a/test/test_parser_version.js
+++ b/test/test_parser_version.js
@@ -68,15 +68,47 @@ describe('parser-version', () => {
         `URL ${url} should point to the eo-maven-plugin POM of 0.28.11`
       );
     });
-    it('returns false when the HTTP call throws', () => {
+    it('skips the check when the HTTP call throws a network error', () => {
       const exists = parserVersion.exists('0.28.11', () => {
         throw new Error('connection refused');
       });
-      assert.strictEqual(exists, false, 'A failing HTTP call should make exists return false');
+      assert.strictEqual(exists, true, 'a network error must not be reported as a missing version');
     });
-    it('returns false when the HTTP status is not 200', () => {
+    it('skips the check when the HTTP call times out', () => {
+      const exists = parserVersion.exists('0.28.11', () => {
+        const error = new Error('socket timeout');
+        error.code = 'ETIMEDOUT';
+        throw error;
+      });
+      assert.strictEqual(exists, true, 'a timeout must not be reported as a missing version');
+    });
+    it('confirms the version when the HTTP status is 200', () => {
+      const exists = parserVersion.exists('0.28.11', () => ({statusCode: 200}));
+      assert.strictEqual(exists, true, 'a 200 response must confirm the version exists');
+    });
+    it('reports the version absent when the HTTP status is 404', () => {
       const exists = parserVersion.exists('0.28.11', () => ({statusCode: 404}));
-      assert.strictEqual(exists, false, 'A non-200 response should make exists return false');
+      assert.strictEqual(exists, false, 'a confirmed 404 must report the version as absent');
+    });
+    it('queries the Maven Central POM URL of the given version', () => {
+      let queried;
+      parserVersion.exists('0.30.0', (method, url) => {
+        queried = url;
+        return {statusCode: 200};
+      });
+      assert.strictEqual(
+        queried,
+        'https://repo.maven.apache.org/maven2/org/eolang/eo-maven-plugin/0.30.0/eo-maven-plugin-0.30.0.pom',
+        'exists must query the POM URL of the requested version'
+      );
+    });
+    it('does not query Maven Central for an undefined version', () => {
+      let called = false;
+      parserVersion.exists(undefined, () => {
+        called = true;
+        return {statusCode: 200};
+      });
+      assert.strictEqual(called, false, 'exists must not hit the network for an undefined version');
     });
   });
 });


### PR DESCRIPTION
`parser-version.js`'s `exists()` caught every error from the HTTP call and returned `false`, lumping a real "version absent" answer together with "could not reach Maven Central". `mvnw.js` then treated that `false` as proof of absence and aborted with "Parser version X is not available in Maven Central" plus `process.exit(1)` — even for the bundled default version, when the only real problem was that the user was offline or Maven Central was briefly unreachable.

`sync-request` throws only on connection or timeout failures; an HTTP 404 comes back as a normal response with a status code. That gives a clean line to draw: a thrown error means the network failed, so `exists()` now warns ("cannot verify parser version, proceeding anyway") and returns `true` so the run continues. A non-200 response is still a confirmed absence and returns `false`, so the genuine "not available" error keeps working. No change is needed in `mvnw.js`.

Tests cover both halves of the split: network error and timeout both skip the check, a 200 confirms the version, a 404 reports it absent, plus the POM URL it queries and that an undefined version never touches the network.

Closes #998