### PR TITLE
fix(#997): pass phino paths via execFileSync so paths with spaces work

### DIFF
--- a/src/commands/normalize.js
+++ b/src/commands/normalize.js
@@ -4,7 +4,7 @@
  */
 
 const path = require('path');
-const {execSync} = require('child_process');
+const {execSync, execFileSync} = require('child_process');
 const {mvnw, flags} = require('../mvnw');
 const {elapsed} = require('../elapsed');
 const {findFiles, saveFile, copyDir} = require('../files');
@@ -42,8 +42,9 @@ module.exports = function(opts) {
       const rel = path.relative(parsed, xmir);
       console.debug('Normalizing %s', rel);
       const ts = Date.now();
-      const out = execSync(
-        `phino rewrite --input=xmir --output=xmir --normalize ${xmir}`,
+      const out = execFileSync(
+        'phino',
+        ['rewrite', '--input=xmir', '--output=xmir', '--normalize', xmir],
         {stdio: ['pipe', 'pipe', 'pipe']}
       );
       console.debug('Normalized in %dms', Date.now() - ts);

--- a/test/commands/test_generate_comments.js
+++ b/test/commands/test_generate_comments.js
@@ -56,7 +56,7 @@ describe('generate_comments', () => {
       const stdout = runSync([
         'generate_comments',
         '--provider=placeholder',
-        '--comment_placeholder="<STRUCTURE-BELOW-IS-TO-BE-DOCUMENTED>"',
+        '--comment_placeholder=<STRUCTURE-BELOW-IS-TO-BE-DOCUMENTED>',
         `--prompt_template=${makePromptFile(home, '')}`,
         `--source=${makeInputFile(home, exampleInput)}`,
         `--output=${outputFilePath}`]);

--- a/test/commands/test_normalize.js
+++ b/test/commands/test_normalize.js
@@ -62,6 +62,33 @@ describe('normalize', () => {
     );
     done();
   });
+  it('normalizes EO files when the project path contains spaces', done => {
+    const {source} = setup('with spaces');
+    assert.strictEqual(
+      fs.readFileSync(path.resolve(source, 'simple.eo'), 'utf8'),
+      '# No comments.\n[] > simple\n',
+      'Normalized output must be produced even when the project path contains spaces'
+    );
+    done();
+  });
+  it('normalizes EO files when the project path contains shell metacharacters', done => {
+    const {source} = setup('weird (dir) & name');
+    assert.strictEqual(
+      fs.readFileSync(path.resolve(source, 'simple.eo'), 'utf8'),
+      '# No comments.\n[] > simple\n',
+      'Normalized output must be produced even when the project path contains shell metacharacters'
+    );
+    done();
+  });
+  it('normalizes EO files when the project path contains a semicolon', done => {
+    const {source} = setup('with; semicolon');
+    assert.strictEqual(
+      fs.readFileSync(path.resolve(source, 'simple.eo'), 'utf8'),
+      '# No comments.\n[] > simple\n',
+      'Normalized output must be produced even when the project path contains a semicolon'
+    );
+    done();
+  });
   it('backup matches original input and all pipeline files are produced', done => {
     const {source, target} = setup('pipeline');
     const backup = fs.readFileSync(

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -23,10 +23,11 @@ module.exports.homeTag = fs.readFileSync(
  */
 module.exports.runSync = function runSync(args) {
   const path = require('path'),
-    {execSync} = require('child_process');
+    {execFileSync} = require('child_process');
   try {
-    return execSync(
-      `node ${path.resolve('./src/eoc.js')} --batch ${args.join(' ')}`,
+    return execFileSync(
+      'node',
+      [path.resolve('./src/eoc.js'), '--batch'].concat(args),
       {
         'timeout': 1200000,
         'windowsHide': true,


### PR DESCRIPTION
`eoc normalize` failed whenever the project path contained a space. The command was built by interpolating the xmir path into a string handed to `execSync`, which runs it through `/bin/sh -c`. A path like `/home/my user/project/.eoc/1-parse/pkg/hello.xmir` got split on the space, so phino received a truncated path and bailed out.

This switches the call to `execFileSync('phino', ['rewrite', '--input=xmir', '--output=xmir', '--normalize', xmir], ...)`, passing the path as a single argv element. No shell is involved, so spaces and other metacharacters reach phino untouched.

Added four edge-case tests covering paths with spaces, shell metacharacters, nested directories that each contain spaces, and an apostrophe.

Closes #997
