### PR TITLE
Add global --dir option to set the working directory

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -111,6 +111,7 @@ program
   .configureHelp({sortOptions: true, sortSubcommands: true});
 
 program
+  .option('-C, --dir <path>', 'Directory where the work should be done', '.')
   .option('-s, --sources <path>', 'Directory with .EO sources', '.')
   .option('-t, --target <path>', 'Directory with all generated files', '.eoc')
   .option('--easy', 'Ignore "warnings" and only fail if there are "errors" or "critical" errors')
@@ -128,6 +129,18 @@ program
   .option('--verbose', 'Print debug messages and full output of child processes')
   .option('--pin <version>', 'Fail if eoc version doesn\'t match exactly', version.what)
   .option('--update-snapshots', 'Update snapshots in the local repository if they are outdated');
+
+program.hook('preAction', (command) => {
+  const dir = command.opts().dir;
+  if (path.resolve(dir) !== process.cwd()) {
+    if (!fs.existsSync(dir)) {
+      console.error('The directory %s does not exist', dir);
+      process.exit(1);
+    }
+    process.chdir(dir);
+    console.debug(`Working directory changed to ${process.cwd()}`);
+  }
+});
 
 program.command('audit')
   .description('Inspect all packages and report their status')

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -133,11 +133,12 @@ program
 program.hook('preAction', (command) => {
   const dir = command.opts().dir;
   if (path.resolve(dir) !== process.cwd()) {
-    if (!fs.existsSync(dir)) {
-      console.error('The directory %s does not exist', dir);
+    try {
+      process.chdir(dir);
+    } catch (err) {
+      console.error('Cannot switch to the working directory %s: %s', dir, err.message);
       process.exit(1);
     }
-    process.chdir(dir);
     console.debug(`Working directory changed to ${process.cwd()}`);
   }
 });

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -80,6 +80,16 @@ describe('eoc', () => {
 });
 
 describe('eoc', () => {
+  it('fails when the --dir directory does not exist', (done) => {
+    assert.throws(
+      () => runSync(['--dir', 'absent-directory-xyz', 'clean']),
+      /Cannot switch to the working directory/
+    );
+    done();
+  });
+});
+
+describe('eoc', () => {
   before(weAreOnline);
   it('fails due version mismatch if different --pin provided', (done) => {
     assert.throws(

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -64,6 +64,22 @@ describe('eoc', () => {
 });
 
 describe('eoc', () => {
+  const fs = require('fs');
+  const os = require('os');
+  const path = require('path');
+  it('does the work in the directory set by --dir', (done) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'eoc-dir-'));
+    fs.mkdirSync(path.join(dir, '.eoc'));
+    const stdout = runSync(['--dir', dir, 'clean']);
+    assert(
+      !fs.existsSync(path.join(dir, '.eoc')),
+      `The .eoc directory under --dir was not deleted\n${stdout}`
+    );
+    done();
+  });
+});
+
+describe('eoc', () => {
   before(weAreOnline);
   it('fails due version mismatch if different --pin provided', (done) => {
     assert.throws(


### PR DESCRIPTION
This adds a global `-C, --dir <path>` option to the `eoc` CLI. A `preAction` hook changes the process working directory into the given path before any command runs, so `--sources`, `--target`, and everything else keep resolving relative to it. It defaults to the current directory and exits with a clear error when the path does not exist.

Until now the only way to build a project in another directory was to `cd` into it first, or to juggle both `--sources` and `--target`. This brings `eoc` in line with the `git -C <dir>` and `make -C <dir>` convention, so `eoc --dir /path/to/project compile` just works.

Closes #1046.