### PR TITLE
#1053: run eoc from the nix store, no home copy, jdk on wrapper path

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+# SPDX-License-Identifier: MIT
+---
+# yamllint disable rule:line-length
+name: nix
+'on':
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+concurrency:
+  group: nix-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  nix:
+    timeout-minutes: 30
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Build the flake
+        run: nix build --print-build-logs .#
+      - name: Run eoc from the store
+        run: nix run .# -- --version

--- a/flake.nix
+++ b/flake.nix
@@ -12,28 +12,17 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; };
-        srcPatched = pkgs.runCommand "patched-src" {} ''
-          cp -r ${./.} $out
-          substituteInPlace $out/package.json \
-            --replace-quiet "\"node\": \"^25.0.0\"," ""
-        '';
-        lockHash = builtins.hashFile "sha512" ./package-lock.json;
         packageJson = builtins.fromJSON (builtins.readFile ./package.json);
-        eolangBase = pkgs.buildNpmPackage {
+        srcPatched = pkgs.runCommand "eoc-src" {} ''
+          cp -r ${./.} $out
+          chmod -R u+w $out
+          ${pkgs.jq}/bin/jq 'del(.engines)' ${./.}/package.json > $out/package.json
+        '';
+      in {
+        packages.default = pkgs.buildNpmPackage {
           pname = packageJson.name;
           version = packageJson.version;
           src = srcPatched;
-
-          buildInputs = [ pkgs.nodejs ];
-          dontNpmBuild = true;
-
-          installPhase = ''
-            mkdir -p $out/lib
-            cp -r . $out/lib
-            mkdir -p $out/bin
-            ln -s $out/lib/src/eoc.js $out/bin/eoc
-            chmod +x $out/bin/eoc
-          '';
 
           npmDeps = pkgs.importNpmLock {
             npmRoot = srcPatched;
@@ -41,40 +30,26 @@
 
           npmConfigHook = pkgs.importNpmLock.npmConfigHook;
 
+          dontNpmBuild = true;
+
+          nativeBuildInputs = [ pkgs.makeWrapper ];
+
+          installPhase = ''
+            runHook preInstall
+            mkdir -p $out/lib
+            cp -r . $out/lib
+            makeWrapper ${pkgs.nodejs}/bin/node $out/bin/eoc \
+              --add-flags "$out/lib/src/eoc.js" \
+              --prefix PATH : ${pkgs.lib.makeBinPath [ pkgs.jdk pkgs.nodejs ]}
+            runHook postInstall
+          '';
+
           meta = with pkgs.lib; {
             description = packageJson.description;
             homepage = packageJson.homepage;
             license = licenses.mit;
-            author = packageJson.author;
+            mainProgram = "eoc";
           };
-        };
-
-        eolangWrapped = pkgs.writeShellScriptBin "eoc" ''
-          set -euo pipefail
-
-          EOC_STORE="${eolangBase}/lib"
-          EOC_STATE="$HOME/.eoc/lib"
-          EOC_HASH="${lockHash}"
-
-          mkdir -p "$EOC_STATE"
-
-          if [ ! -f "$EOC_STATE/.hash" ] || [ "$(cat $EOC_STATE/.hash)" != "$EOC_HASH" ]; then
-            rm -rf "$EOC_STATE/"
-            cp -r "$EOC_STORE/" "$EOC_STATE/"
-            chmod -R 755 "$EOC_STATE/"
-            echo "$EOC_HASH" > "$EOC_STATE/.hash"
-          fi
-
-          exec "${pkgs.nodejs}/bin/node" "$EOC_STATE/src/eoc.js" "$@"
-        '';
-
-      in {
-        packages.default = eolangWrapped;
-        meta = with pkgs.lib; {
-          description = packageJson.description;
-          homepage = packageJson.homepage;
-          license = licenses.mit;
-          author = packageJson.author;
         };
       }
     );


### PR DESCRIPTION
Closes #1053.

The flake now installs `eoc` the way Nix packages are supposed to work: the tool runs straight from the read-only store, there is no copy into `$HOME/.eoc`, and the wrapper is self contained.

What changed:

- The `$HOME/.eoc/lib` copy-out and its lockfile-hash invalidation are gone. The wrapper is a `makeWrapper` script that runs `node $out/lib/src/eoc.js` directly from the store. No stale copies, no `rm -rf` races, upgrades and rollbacks are atomic store path switches.
- The `engines` field is removed from `package.json` with `jq 'del(.engines)'` instead of a byte-exact `substituteInPlace` string, so the patch cannot silently rot when the version in `engines` is bumped or the file is reformatted.
- `jdk` is added to the wrapper PATH. Before this, `nix run` on a machine without a system Java died with `The JAVA_HOME environment variable is not defined correctly` as soon as `eoc` reached mvnw.
- The stray top-level `meta` output (ignored by Nix) is removed; the package `meta` now carries `mainProgram = "eoc"` so `nix run` resolves the binary by convention.

Verified on a NixOS machine that has no system Java at all:

- `nix build` succeeds, `eoc --version` works.
- `eoc --easy dataize app` on a hello-world program runs the whole pipeline (parse, assemble, lint, transpile) with `mvnw` executing from `/nix/store/...`, writing only into the working directory; `$HOME/.eoc` is never created.
- Control run with the previous flake on the same machine: it fails immediately with the `JAVA_HOME` error above and leaves a copy in `$HOME/.eoc/lib`.

The remaining failure in that smoke test is an upstream toolchain issue (the default `eo-maven-plugin` 0.61.0 with tag 0.59.7 fails linting on the downloaded runtime sources) and happens identically with any installation method; it is unrelated to the packaging.
