### PR TITLE
feat(#1016): add CLI option to override lints version via --lints

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -118,6 +118,7 @@ program
   .option('--blind', 'Disable linting')
   .option('--home-tag <version>', 'Git tag in objectionary/home to compile against', tag)
   .option('--parser <version>', 'Set the version of EO parser to use', parser)
+  .option('--lints <version>', 'Set the version of EO lints to use')
   .option('--latest', 'Use the latest parser version from Maven Central')
   .option('--alone', 'Just run a single command without dependencies')
   .option('-l, --language <name>', 'Language of target execution platform (Java or JavaScript, case-insensitive)', language.java)

--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -64,6 +64,7 @@ module.exports.flags = function(opts) {
   return [
     `-Deo.version=${opts.parser}`,
     `-Deo.tag=${opts.homeTag ? opts.homeTag : opts.parser}`,
+    opts.lints ? `-Deo.lintsVersion=${opts.lints}` : '',
     opts.verbose ? '--errors' : '',
     opts.verbose ? '' : '--quiet',
     opts.debug ? '--debug' : '',

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -57,6 +57,10 @@ describe('eoc', () => {
     assert.strictEqual(eoc('--language=JAVA', 'clean').status, 0);
     done();
   });
+  it('accepts the --lints option', (done) => {
+    assert.strictEqual(eoc('--lints=0.0.42', 'clean').status, 0);
+    done();
+  });
   it('rejects an unknown --language value', (done) => {
     assert.notStrictEqual(eoc('--language=Eiffel', 'clean').status, 0);
     done();

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -26,6 +26,18 @@ describe('mvnw', () => {
     assert.ok(args.includes('-Deo.tag=homeTag'));
     assert.ok(args.includes('-Deo.version=0.28.11'));
   });
+  it('sets lints version flag from options', () => {
+    const opts = {
+      sources: 'sources',
+      target: 'target',
+      lints: '0.0.42'
+    };
+    const result = flags(opts);
+    assert.ok(
+      result.includes('-Deo.lintsVersion=0.0.42'),
+      'Expected -Deo.lintsVersion=0.0.42 to be present in maven flags'
+    );
+  });
   it('includes slf4j-simple timestamp flags', () => {
     const opts = {
       sources: 'sources',


### PR DESCRIPTION
Closes #1016

## Description

Adds a new `--lints` CLI option to `eoc`, allowing users to specify which version of EO lints to use.

### Problem
Currently, `eoc` allows pinning the parser version via `--parser` but has no equivalent for lints. This makes it impossible to test new or pre-release lint rules.
