### PR TITLE
#1066: fix engines.node to match actually tested Node version

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "nyc": "^18.0.0"
   },
   "engines": {
-    "node": ">6.0",
+    "node": ">=18",
     "npm": ">8.0"
   },
   "homepage": "https://github.com/objectionary/eoc",


### PR DESCRIPTION
Closes #1066.

`package.json` claimed `engines.node` `>6.0`, but `src/eoc.js` uses object spread syntax, which needs ES2018 (Node 8.3+). The actual CI test matrix (`grunt.yml`, `itest.yml`) only tests Node 18. Changed `engines.node` to `>=18` to match what is actually tested and actually works.

Verified: `npx eslint .` clean, `package.json` still valid JSON.
