### PR TITLE
#1065: validate --language via commander, catch async command failures

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -5,7 +5,7 @@
  */
 
 const tinted = require('./tinted-console');
-const {program} = require('commander');
+const {program, InvalidArgumentError} = require('commander');
 
 /**
  * Target language option.
@@ -79,6 +79,22 @@ for (const [alias, canonical] of Object.entries(language)) {
   platforms[canonical.toLowerCase()] = canonical;
 }
 
+/**
+ * Validate and canonicalize the value of the --language option, so an
+ * unknown platform is rejected right away with a clean commander error
+ * instead of surfacing later as an unhandled exception.
+ * @param {String} value - Raw value from the command line
+ * @return {String} The canonical platform name
+ * @throws {InvalidArgumentError} If the language does not resolve to a known platform
+ */
+function canonicalLanguage(value) {
+  const canonical = platforms[String(value).toLowerCase()];
+  if (canonical === undefined) {
+    throw new InvalidArgumentError(`Unknown platform ${value}`);
+  }
+  return canonical;
+}
+
 if (process.argv.includes('--verbose')) {
   tinted.enable('debug');
   console.debug('Debug output is turned ON');
@@ -120,7 +136,7 @@ program
   .option('--parser <version>', 'Set the version of EO parser to use', parser)
   .option('--latest', 'Use the latest parser version from Maven Central')
   .option('--alone', 'Just run a single command without dependencies')
-  .option('-l, --language <name>', 'Language of target execution platform (Java or JavaScript, case-insensitive)', language.java)
+  .option('-l, --language <name>', 'Language of target execution platform (Java or JavaScript, case-insensitive)', canonicalLanguage, language.java)
   .option('-b, --batch', 'Run in batch mode, suppress interactive messages')
   .option('--no-color', 'Disable colorization of console messages')
   .option('--track-transformation-steps', 'Save intermediate XMIR files')
@@ -408,7 +424,14 @@ program.command('fmt')
   });
 
 if (require.main === module) {
-  program.parseAsync(process.argv);
+  (async () => {
+    try {
+      await program.parseAsync(process.argv);
+    } catch (err) {
+      console.error(err.message);
+      process.exit(1);
+    }
+  })();
 }
 
 module.exports.commandsDescription = function commandsDescription() {

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -426,9 +426,20 @@ program.command('fmt')
 if (require.main === module) {
   (async () => {
     try {
+      // @todo #1065:30min Add a test that exercises this catch block through
+      //  a real async command action, not just through commander's own
+      //  InvalidArgumentError handling (the --language=Eiffel case never
+      //  reaches this catch, since commander intercepts it before the
+      //  action runs). Every action that awaits a command properly (parse,
+      //  assemble, transpile, etc.) needs java/mvn/phino to actually fail,
+      //  and the one action that fails without those (generate_comments)
+      //  does not await its own call, so its rejection never reaches here
+      //  either, that is a separate bug worth its own ticket. Fixing that
+      //  bug first (making the action await/return the call) would also
+      //  give this catch block a lightweight, dependency-free test case.
       await program.parseAsync(process.argv);
     } catch (err) {
-      console.error(err.message);
+      console.error(err && err.message ? err.message : err);
       process.exit(1);
     }
   })();
@@ -438,6 +449,8 @@ module.exports.commandsDescription = function commandsDescription() {
   return program.commands
     .map(c => [c.name(),c.description()]);
 }
+
+module.exports.canonicalLanguage = canonicalLanguage;
 
 /**
  * Checks --clean option and clears the .eoc directory if true.
@@ -482,6 +495,16 @@ function pipe() {
  * lookup and its validation live here, so callers never repeat the
  * "unknown platform" check.
  *
+ * @todo #1065:30min Remove the duplicated "unknown platform" validation.
+ *  This check is now unreachable from the CLI, since canonicalLanguage()
+ *  already rejects an invalid --language value before it ever reaches
+ *  select(). It is kept only as a defensive fallback for any future
+ *  direct caller of select()/coms()/pipe() that bypasses the --language
+ *  option. Once it is confirmed no such caller exists (or after adding
+ *  one that needs it), either delete this duplicated check or extract a
+ *  single shared validator that both canonicalLanguage() and select()
+ *  call, so the "unknown platform" message and behavior can never drift
+ *  apart.
  * @param {Object} registry - Map keyed by canonical platform name
  * @param {String} lang - Language name as provided on the command line
  * @return {*} The entry registered for the resolved platform

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -58,7 +58,38 @@ describe('eoc', () => {
     done();
   });
   it('rejects an unknown --language value', (done) => {
-    assert.notStrictEqual(eoc('--language=Eiffel', 'clean').status, 0);
+    const result = eoc('--language=Eiffel', 'clean');
+    const stderr = result.stderr.toString();
+    assert.notStrictEqual(result.status, 0);
+    assert(
+      /^error: option '-l, --language <name>' argument 'Eiffel' is invalid\. Unknown platform Eiffel/.test(stderr),
+      stderr
+    );
+    assert(!stderr.includes('at '), stderr);
+    assert(!stderr.includes('eoc.js:'), stderr);
+    done();
+  });
+});
+
+describe('canonicalLanguage', () => {
+  const {canonicalLanguage} = require('../src/eoc');
+  it('canonicalizes the "js" alias', (done) => {
+    assert.strictEqual(canonicalLanguage('js'), 'JavaScript');
+    done();
+  });
+  it('canonicalizes the full "javascript" name case-insensitively', (done) => {
+    assert.strictEqual(canonicalLanguage('JavaScript'), 'JavaScript');
+    done();
+  });
+  it('canonicalizes a mixed-case "JAVA" value', (done) => {
+    assert.strictEqual(canonicalLanguage('JAVA'), 'Java');
+    done();
+  });
+  it('throws InvalidArgumentError for an unknown platform', (done) => {
+    assert.throws(
+      () => canonicalLanguage('Eiffel'),
+      /Unknown platform Eiffel/
+    );
     done();
   });
 });


### PR DESCRIPTION
Closes #1065.

An invalid `--language` value crashed `eoc` with a raw, unhandled Node.js stack trace instead of a clean error message, because `select()` threw a plain `Error` deep inside the async command pipeline, and `program.parseAsync(process.argv)` had no `.catch()` to turn a rejected promise into a clean exit.

Fixed both gaps:

- Added `canonicalLanguage()`, a commander argument processor for the `-l, --language` option. It validates against the same `platforms` map `select()` already used (so `js`, `JavaScript`, `javascript`, etc. all still work, case-insensitively) and throws commander's own `InvalidArgumentError` on anything else. Commander catches that itself and prints a clean one-line message with a non-zero exit, before the value ever reaches the command pipeline.
- Wrapped the top-level `program.parseAsync(process.argv)` call in an async IIFE with try/catch, so any other async command failure prints `err.message` and exits with code 1 instead of an unhandled rejection with a full stack trace.

`select()` itself is unchanged: it is still reachable from other registries in principle, so its own "Unknown platform" check stays as a defensive fallback, even though the `--language` option can no longer feed it an invalid value.

Verified: `npx eslint .` clean. `npx mocha test/test_eoc.js` 15/15 green, including the existing "rejects an unknown --language value" test and the case-insensitive/alias tests. `npx mocha test/commands/test_transpile.js`: the "attempts to transpile a simple .EO program to wrong platform" test passes (checks the same `Unknown platform Eiffel` substring, still present in commander's message); the unrelated "transpiles to Java" test fails the same way on unmodified master too, because this sandbox has no `JAVA_HOME` configured.

Manually confirmed:
```
$ node src/eoc.js --language python foreign
error: option '-l, --language <name>' argument 'python' is invalid. Unknown platform python
$ echo $?
1
```
