### PR TITLE
#1064: refuse to delete cwd, its ancestors, or the home directory

### DIFF
--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -9,19 +9,19 @@ const path = require('path');
 const os = require('os');
 
 /**
- * Checks that deleting the given directory would not destroy anything
- * outside the project's own temporary files: the current working
- * directory itself, an ancestor of it, or the user's home directory.
+ * Refuses, by throwing, to delete a directory that is the current
+ * working directory, an ancestor of it, or the user's home directory.
  * @param {String} target - Resolved absolute path of the directory to delete
- * @return {Boolean} True when the target is not the current directory,
- *  an ancestor of it, or the home directory
  */
-function isSafeToDelete(target) {
+function guard(target) {
   const cwd = process.cwd();
-  const fromTargetToCwd = path.relative(target, cwd);
-  const targetIsCwdOrAncestor = fromTargetToCwd === '' ||
-    (!fromTargetToCwd.startsWith('..') && !path.isAbsolute(fromTargetToCwd));
-  return !targetIsCwdOrAncestor && target !== os.homedir();
+  const route = path.relative(target, cwd);
+  const encloses = route === '' || (!route.startsWith('..') && !path.isAbsolute(route));
+  if (encloses || target === os.homedir()) {
+    throw new Error(
+      `Refusing to delete ${rel(target)}: it is the current directory, an ancestor of it, or the home directory`
+    );
+  }
 }
 
 /**
@@ -30,11 +30,7 @@ function isSafeToDelete(target) {
  */
 module.exports = function(opts) {
   const home = path.resolve(opts.target);
-  if (!isSafeToDelete(home)) {
-    throw new Error(
-      `Refusing to delete ${rel(home)}: it is the current directory, an ancestor of it, or the home directory`
-    );
-  }
+  guard(home);
   if (fs.existsSync(home)) {
     fs.rmSync(home, {recursive: true, force: true});
     console.info('The directory %s was deleted', rel(home));

--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -10,10 +10,13 @@ const os = require('os');
 
 /**
  * Refuses, by throwing, to delete a directory that is the current
- * working directory, an ancestor of it, or the user's home directory.
+ * working directory, an ancestor of it, or the user's home directory;
+ * otherwise returns it unchanged, so the guard cannot be skipped or
+ * reordered away from the value it protects.
  * @param {String} target - Resolved absolute path of the directory to delete
+ * @return {String} The same target, once confirmed safe to delete
  */
-function guard(target) {
+function guarded(target) {
   const cwd = process.cwd();
   const route = path.relative(target, cwd);
   const encloses = route === '' || (!route.startsWith('..') && !path.isAbsolute(route));
@@ -22,6 +25,7 @@ function guard(target) {
       `Refusing to delete ${rel(target)}: it is the current directory, an ancestor of it, or the home directory`
     );
   }
+  return target;
 }
 
 /**
@@ -29,8 +33,7 @@ function guard(target) {
  * @param {Hash} opts - All options
  */
 module.exports = function(opts) {
-  const home = path.resolve(opts.target);
-  guard(home);
+  const home = guarded(path.resolve(opts.target));
   if (fs.existsSync(home)) {
     fs.rmSync(home, {recursive: true, force: true});
     console.info('The directory %s was deleted', rel(home));

--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -9,11 +9,32 @@ const path = require('path');
 const os = require('os');
 
 /**
+ * Checks that deleting the given directory would not destroy anything
+ * outside the project's own temporary files: the current working
+ * directory itself, an ancestor of it, or the user's home directory.
+ * @param {String} target - Resolved absolute path of the directory to delete
+ * @return {Boolean} True when the target is not the current directory,
+ *  an ancestor of it, or the home directory
+ */
+function isSafeToDelete(target) {
+  const cwd = process.cwd();
+  const fromTargetToCwd = path.relative(target, cwd);
+  const targetIsCwdOrAncestor = fromTargetToCwd === '' ||
+    (!fromTargetToCwd.startsWith('..') && !path.isAbsolute(fromTargetToCwd));
+  return !targetIsCwdOrAncestor && target !== os.homedir();
+}
+
+/**
  * Deletes all temporary files.
  * @param {Hash} opts - All options
  */
 module.exports = function(opts) {
   const home = path.resolve(opts.target);
+  if (!isSafeToDelete(home)) {
+    throw new Error(
+      `Refusing to delete ${rel(home)}: it is the current directory, an ancestor of it, or the home directory`
+    );
+  }
   if (fs.existsSync(home)) {
     fs.rmSync(home, {recursive: true, force: true});
     console.info('The directory %s was deleted', rel(home));

--- a/test/commands/test_clean.js
+++ b/test/commands/test_clean.js
@@ -51,4 +51,45 @@ describe('clean', () => {
     assert(fs.existsSync(eoDir), stdout);
     done();
   });
+  it('refuses to delete the current working directory', (done) => {
+    const {spawnSync} = require('child_process');
+    const home = path.resolve(testDir, 'refuses-cwd');
+    fs.rmSync(home, {recursive: true, force: true});
+    fs.mkdirSync(home, {recursive: true});
+    const s = spawnSync(
+      'node', [path.resolve('./src/eoc.js'), '--target', '.', 'clean'],
+      {cwd: home}
+    );
+    assert(s.status !== 0, s.stderr.toString());
+    assert(s.stderr.toString().includes('Refusing to delete'), s.stderr.toString());
+    assert(fs.existsSync(home), 'the current directory must not be deleted');
+    done();
+  });
+  it('refuses to delete an ancestor of the current working directory', (done) => {
+    const {spawnSync} = require('child_process');
+    const home = path.resolve(testDir, 'refuses-ancestor'),
+      nested = path.resolve(home, 'nested');
+    fs.rmSync(home, {recursive: true, force: true});
+    fs.mkdirSync(nested, {recursive: true});
+    const s = spawnSync(
+      'node', [path.resolve('./src/eoc.js'), '--target', '..', 'clean'],
+      {cwd: nested}
+    );
+    assert(s.status !== 0, s.stderr.toString());
+    assert(fs.existsSync(home), 'the ancestor directory must not be deleted');
+    done();
+  });
+  it('refuses to delete the home directory', (done) => {
+    const {spawnSync} = require('child_process');
+    const fakeHome = path.resolve(testDir, 'fake-home');
+    fs.rmSync(fakeHome, {recursive: true, force: true});
+    fs.mkdirSync(fakeHome, {recursive: true});
+    const s = spawnSync(
+      'node', [path.resolve('./src/eoc.js'), '--target', fakeHome, 'clean'],
+      {env: {...process.env, HOME: fakeHome, USERPROFILE: fakeHome}}
+    );
+    assert(s.status !== 0, s.stderr.toString());
+    assert(fs.existsSync(fakeHome), 'the home directory must not be deleted');
+    done();
+  });
 });


### PR DESCRIPTION
Closes #1064.

`eoc clean --target <path>` deleted the resolved target with `fs.rmSync(home, {recursive: true, force: true})` with no check that the path was not the current working directory, an ancestor of it, or the user's home directory. A typo in `--target` (for example `.` instead of the documented default `.eoc`) silently wiped a project or its parent with no prompt.

Added `isSafeToDelete()` in `src/commands/clean.js`: it refuses (throws) when the resolved target equals `process.cwd()`, is an ancestor of it (checked via `path.relative`, so it works for any depth), or equals `os.homedir()`. This matches the existing codebase convention of command modules throwing a plain `Error` for validation failures (see `normalize.js`, `lint.js`, `docs.js`).

Three new tests in `test/commands/test_clean.js` cover the three refusal cases; the two existing tests (delete with/without `--global`) still pass unchanged, confirming the normal `.eoc`-subdirectory case is unaffected.

Verified: `npx eslint .` clean. `npx mocha test/commands/test_clean.js` 5/5 green. `npx mocha test/test_eoc.js` 15/15 green (no regressions).

Manually confirmed:
```
$ mkdir eoc-clean-test && cd eoc-clean-test && touch important-file.txt
$ node path/to/eoc.js --target . clean
Error: Refusing to delete .: it is the current directory, an ancestor of it, or the home directory
$ ls
important-file.txt
```
