### PR TITLE
fix(#1071): await generate_comments action so failures reach the top-level catch

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -352,8 +352,8 @@ program.command('generate_comments')
   .requiredOption('--prompt_template <path>',
     'Path to prompt template file, ' +
     'where `{code}` placeholder will be replaced with the code given by the user')
-  .action((str, opts) => {
-    coms().generate_comments({...program.opts(), ...str});
+  .action(async (str, opts) => {
+    await coms().generate_comments({...program.opts(), ...str});
   });
 
 program.command('jeo:disassemble')
@@ -426,17 +426,6 @@ program.command('fmt')
 if (require.main === module) {
   (async () => {
     try {
-      // @todo #1065:30min Add a test that exercises this catch block through
-      //  a real async command action, not just through commander's own
-      //  InvalidArgumentError handling (the --language=Eiffel case never
-      //  reaches this catch, since commander intercepts it before the
-      //  action runs). Every action that awaits a command properly (parse,
-      //  assemble, transpile, etc.) needs java/mvn/phino to actually fail,
-      //  and the one action that fails without those (generate_comments)
-      //  does not await its own call, so its rejection never reaches here
-      //  either, that is a separate bug worth its own ticket. Fixing that
-      //  bug first (making the action await/return the call) would also
-      //  give this catch block a lightweight, dependency-free test case.
       await program.parseAsync(process.argv);
     } catch (err) {
       console.error(err && err.message ? err.message : err);

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -95,6 +95,36 @@ describe('canonicalLanguage', () => {
 });
 
 describe('eoc', () => {
+  const {spawnSync} = require('child_process');
+  const path = require('path');
+  const eoc = function(...args) {
+    return spawnSync('node', [path.resolve('./src/eoc.js'), '--batch', ...args]);
+  };
+  it('reports a failing async command cleanly without leaking a stack trace', (done) => {
+    const result = eoc(
+      'generate_comments', '--provider=no-such-llm',
+      '--source=absent.eo', '--prompt_template=absent.txt'
+    );
+    const stderr = result.stderr.toString();
+    assert.notStrictEqual(result.status, 0);
+    assert(stderr.includes('`no-such-llm` provider is not supported'), stderr);
+    assert(!/\.js:\d+/.test(stderr), stderr);
+    done();
+  });
+  it('reports a filesystem error from an async command without a stack trace', (done) => {
+    const result = eoc(
+      'generate_comments', '--provider=placeholder',
+      '--source=absent.eo', '--prompt_template=absent.txt'
+    );
+    const stderr = result.stderr.toString();
+    assert.notStrictEqual(result.status, 0);
+    assert(stderr.includes('no such file or directory'), stderr);
+    assert(!/\.js:\d+/.test(stderr), stderr);
+    done();
+  });
+});
+
+describe('eoc', () => {
   const fs = require('fs');
   const os = require('os');
   const path = require('path');


### PR DESCRIPTION
The `generate_comments` command action called its async command without awaiting it, so any failure escaped as an unhandled promise rejection with a full stack trace instead of the clean, one-line message the top-level `catch` in `eoc.js` is meant to print. That catch block therefore had no path that reached it from a real command, which is what the #1065 puzzle flagged.

Awaiting the call inside the action lets the rejection propagate through `parseAsync` into the catch, so a failing command now exits with code 1 and a single readable line.

Two tests cover the catch through distinct error types — a custom `Error` from an unknown `--provider`, and a Node `ENOENT` from a missing template file — each asserting a non-zero exit and the absence of any `.js:line` stack frames. Both need no Java, Maven, or network, so they stay fast and hermetic. The resolved puzzle text is removed.

Closes #1071.