### PR TITLE
fix: put XML declaration first in mvnw/pom.xml so xcop passes

### DIFF
--- a/mvnw/pom.xml
+++ b/mvnw/pom.xml
@@ -1,7 +1,7 @@
-<!--
 <?xml version="1.0" encoding="UTF-8"?>
- * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
- * SPDX-License-Identifier: MIT
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
The xcop check is failing on `master` for every pull request. The cause is in `mvnw/pom.xml`: the XML declaration was sitting on the second line, inside the license comment, so the file opened with `<!--` and xcop reported invalid formatting (a declaration is only valid as the very first line of a document).

This moves `<?xml version="1.0" encoding="UTF-8"?>` to the first line, above the SPDX comment, and drops the leading space from the two comment body lines so they match xcop's canonical layout for a top-level comment.

Verified with xcop 0.11.0 locally (`XCOP PASS`) and confirmed the file still parses as valid XML. No other files are touched.

It is a small formatting fix, so it stays well under the usual size guideline; there is nothing testable to add for an XML header.