### PR TITLE
fix: print resolved paths in jeo commands (#1088)

### DIFF
--- a/src/commands/jeo/assemble.js
+++ b/src/commands/jeo/assemble.js
@@ -27,9 +27,7 @@ module.exports = function(opts) {
         ),
       opts.target, opts.batch
     );
-    tracked.print(
-      `EO .xmir files from ${rel(opts.xmirs)} assembled to .class files in ${rel(opts.classes)}`
-    );
+    tracked.print(`EO .xmir files from ${rel(path.resolve(opts.target, opts.xmirs))} assembled to .class files in ${rel(path.resolve(opts.target, opts.classes))}`);
     return r;
   });
 };

--- a/src/commands/jeo/disassemble.js
+++ b/src/commands/jeo/disassemble.js
@@ -27,9 +27,7 @@ module.exports = function(opts) {
         ),
       opts.target, opts.batch
     );
-    tracked.print(
-      `Bytecode .class files from ${rel(opts.classes)} disassembled to .xmir files in ${rel(opts.xmirs)}`
-    );
+    tracked.print(`Bytecode .class files from ${rel(path.resolve(opts.target, opts.classes))} disassembled to .xmir files in ${rel(path.resolve(opts.target, opts.xmirs))}`);
     return r;
   });
 };


### PR DESCRIPTION
Fixes #1088
Changed the success message in `assemble.js` and `disassemble.js` to use
`path.resolve(opts.target, opts.xmirs)` and `path.resolve(opts.target, opts.classes)`
instead of the raw option values. This ensures the printed paths match
the actual paths passed to Maven.

Before:
```js
tracked.print(`EO .xmir files from ${rel(opts.xmirs)} assembled to .class files in ${rel(opts.classes)}`);