### PR TITLE
fix(#1083): group docs packages in a Map so prototype-named packages do not crash

### DIFF
--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -129,7 +129,7 @@ module.exports = function(opts) {
       fs.mkdirSync(output, {recursive: true});
       const css = path.join(output, 'styles.css');
       fs.writeFileSync(css, '');
-      const packages_info = {};
+      const packages_info = new Map();
       const all_xmir_htmls = [];
       const xmirs = findFiles(input, '.xmir');
       for (const xmir of xmirs) {
@@ -141,33 +141,32 @@ module.exports = function(opts) {
         fs.writeFileSync(html_app, wrapHtml(name, xmir_html, css));
         const packages = path.dirname(relative).split(path.sep).join('.');
         const html_package = path.join(output, `package_${packages}.html`);
-        if (!(packages in packages_info)) {
-          packages_info[packages] = {
+        if (!packages_info.has(packages)) {
+          packages_info.set(packages, {
             xmir_htmls : [],
             names: [],
             path: html_package
-          };
+          });
         }
-        packages_info[packages].xmir_htmls.push(xmir_html);
-        packages_info[packages].names.push(name);
+        packages_info.get(packages).xmir_htmls.push(xmir_html);
+        packages_info.get(packages).names.push(name);
         all_xmir_htmls.push(xmir_html);
       }
-      for (const package_name of Object.keys(packages_info)) {
-        fs.mkdirSync(path.dirname(packages_info[package_name].path), {recursive: true});
-        fs.writeFileSync(packages_info[package_name].path,
-          generatePackageHtml(`${package_name} package`, packages_info[package_name].xmir_htmls, css));
+      for (const [package_name, info] of packages_info) {
+        fs.mkdirSync(path.dirname(info.path), {recursive: true});
+        fs.writeFileSync(info.path,
+          generatePackageHtml(`${package_name} package`, info.xmir_htmls, css));
       }
       const packages = path.join(output, 'packages.html');
       fs.writeFileSync(packages, generatePackageHtml('overall package', all_xmir_htmls, css));
       const summary = path.join(output, 'summary.xml');
-      const pkgNames = Object.keys(packages_info);
       const lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',
-        `<eodoc packages="${pkgNames.length}" objects="${xmirs.length}">`
+        `<eodoc packages="${packages_info.size}" objects="${xmirs.length}">`
       ];
-      for (const pkg of pkgNames) {
+      for (const [pkg, info] of packages_info) {
         lines.push(`  <package name="${xmlEscape(pkg)}">`);
-        for (const obj of packages_info[pkg].names) {
+        for (const obj of info.names) {
           lines.push(`    <object name="${xmlEscape(obj)}"/>`);
         }
         lines.push('  </package>');

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -48,6 +48,25 @@ describe('docs', () => {
     done();
   });
   /**
+   * Tests that 'docs' does not crash for a package whose name is an
+   * inherited object property, such as 'constructor'.
+   * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
+   */
+  it('generates HTML for a package named after an object prototype member', (done) => {
+    const sample = path.join(parsed, 'constructor');
+    fs.mkdirSync(sample, {recursive: true});
+    fs.writeFileSync(path.join(sample, 'foo.xmir'), '<program name="test" />');
+    runSync([
+      'docs',
+      '--verbose',
+      '-s', path.resolve(home, 'src'),
+      '-t', home,
+    ]);
+    const package_html = path.join(docs, 'package_constructor.html');
+    assert(fs.existsSync(package_html), `Expected file ${package_html} but it was not created`);
+    done();
+  });
+  /**
    * Tests that the 'docs' command generates a summary.xml with correct counts.
    * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
    */


### PR DESCRIPTION
The `docs` command grouped packages in a plain object and checked membership with the `in` operator, which walks the prototype chain. A package named after an inherited property — `constructor`, and likewise `toString`, `valueOf`, `hasOwnProperty` — was treated as already present, so its entry was never initialized and pushing to `xmir_htmls` dereferenced `undefined`, crashing the command with `Cannot read properties of undefined (reading 'push')`.

Switching the grouping to a `Map` keys on the string directly, so every package name is handled regardless of what it collides with on `Object.prototype`, including `__proto__` (where a plain-object assignment would otherwise set the prototype instead of a key).

Added a regression test that runs `docs` on a `constructor` package and asserts the package page is generated.

Verified: `npx mocha test/commands/test_docs.js` 10/10 passing, `npx eslint .` clean.

Closes #1083.