### PR TITLE
fix(#1085): only treat a 404 as a confirmed-absent parser version

### DIFF
--- a/src/parser-version.js
+++ b/src/parser-version.js
@@ -48,7 +48,16 @@ const request = require('sync-request'),
       if (ver && ver !== 'undefined') {
         try {
           const res = fetch('GET', version.url(ver), {timeout: 10000, socketTimeout: 10000});
-          result = res.statusCode === 200;
+          if (res.statusCode === 404) {
+            result = false;
+          } else {
+            if (res.statusCode !== 200) {
+              console.warn(colors.yellow(
+                `Cannot verify parser version ${ver} in Maven Central (HTTP ${res.statusCode}), proceeding anyway`
+              ));
+            }
+            result = true;
+          }
         } catch (e) {
           console.warn(colors.yellow(
             `Cannot verify parser version ${ver} in Maven Central (${e.message}), proceeding anyway`

--- a/test/test_parser_version.js
+++ b/test/test_parser_version.js
@@ -90,6 +90,42 @@ describe('parser-version', () => {
       const exists = parserVersion.exists('0.28.11', () => ({statusCode: 404}));
       assert.strictEqual(exists, false, 'a confirmed 404 must report the version as absent');
     });
+    it('assumes the version exists when Maven Central returns a transient 503', () => {
+      const exists = parserVersion.exists('0.28.11', () => ({statusCode: 503}));
+      assert.strictEqual(exists, true, 'a transient 503 must not be reported as a missing version');
+    });
+    it('assumes the version exists when Maven Central returns 429 rate limited', () => {
+      const exists = parserVersion.exists('0.28.11', () => ({statusCode: 429}));
+      assert.strictEqual(exists, true, 'a 429 rate limit must not be reported as a missing version');
+    });
+    it('assumes the version exists when Maven Central returns a 502 bad gateway', () => {
+      const exists = parserVersion.exists('0.28.11', () => ({statusCode: 502}));
+      assert.strictEqual(exists, true, 'a 502 bad gateway must not be reported as a missing version');
+    });
+    it('assumes the version exists for any other non-404 server error', () => {
+      const exists = parserVersion.exists('0.28.11', () => ({statusCode: 500}));
+      assert.strictEqual(exists, true, 'a 500 server error must not be reported as a missing version');
+    });
+    it('assumes the version exists when Maven Central answers with a 301 redirect', () => {
+      const exists = parserVersion.exists('0.28.11', () => ({statusCode: 301}));
+      assert.strictEqual(exists, true, 'a 301 redirect must not be reported as a missing version');
+    });
+    it('assumes the version exists when Maven Central answers with a 403 forbidden', () => {
+      const exists = parserVersion.exists('0.28.11', () => ({statusCode: 403}));
+      assert.strictEqual(exists, true, 'a 403 forbidden must not be reported as a missing version');
+    });
+    it('queries the correct POM URL even when the response is a transient error', () => {
+      let queried;
+      parserVersion.exists('0.31.0', (method, url) => {
+        queried = url;
+        return {statusCode: 503};
+      });
+      assert.strictEqual(
+        queried,
+        'https://repo.maven.apache.org/maven2/org/eolang/eo-maven-plugin/0.31.0/eo-maven-plugin-0.31.0.pom',
+        'exists must query the POM URL even for a non-200 response'
+      );
+    });
     it('queries the Maven Central POM URL of the given version', () => {
       let queried;
       parserVersion.exists('0.30.0', (method, url) => {


### PR DESCRIPTION
`parser-version.js`'s `exists()` reduced any response to `res.statusCode === 200`, so every non-200 status collapsed to `false`. A transient `503`/`502`/`429` from Maven Central was therefore indistinguishable from a real `404`, and the CLI rejected a perfectly valid parser version — even the bundled default from `eo-version.txt` — with a misleading "not available in Maven Central" error. #998/PR #1020 fixed this for the exception path only; the response path stayed broken.

`exists()` now treats only a `404` as confirmed-absent. Any other non-200 status is handled the same way as a thrown network error: it warns (`Cannot verify parser version X in Maven Central (HTTP 503), proceeding anyway`) and assumes the version exists, since a non-404 does not confirm absence. A clean `200` still verifies silently.

The structure has one special case (`404` → absent) and a single general "otherwise it exists" branch, so it covers every other status rather than enumerating specific codes. Tests exercise the whole range: `503`, `429`, `502`, `500`, `301`, `403` all remain `true`, while `200`/`404` keep their existing behaviour, plus a check that the correct POM URL is still queried on an error response.

Verified: `npx mocha test/test_parser_version.js` 23/23 passing, `npx eslint .` clean.

Closes #1085.