### PR TITLE
fix(#1089): preserve the original XSL error as cause when docs wraps it

### DIFF
--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -70,7 +70,7 @@ function createXmirHtmlBlock(filepath) {
     const xsl = fs.readFileSync(path.join(__dirname, '..', 'resources', 'xmir-transformer.xsl')).toString();
     return convertMarkdownToHtml(transformDocument(xmir, xsl));
   } catch(error) {
-    throw new Error(`Error while applying XSL to XMIR: ${error.message}`, error);
+    throw new Error(`Error while applying XSL to XMIR: ${error.message}`, {cause: error});
   }
 }
 
@@ -183,3 +183,5 @@ module.exports = function(opts) {
     }
   });
 };
+
+module.exports.createXmirHtmlBlock = createXmirHtmlBlock;

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -253,4 +253,58 @@ describe('docs', () => {
     assert(test_content.includes('<code>Code test</code>'), `Markdown not processed correctly in ${test_html}`);
     done();
   });
+  /**
+   * Tests that createXmirHtmlBlock keeps the original error as the cause
+   * when the XSL transform fails, instead of silently discarding it.
+   * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
+   */
+  it('preserves the original error as the cause when the XSL transform fails', (done) => {
+    const bad = path.join(parsed, 'bad.xmir');
+    fs.writeFileSync(bad, 'not valid xmir <<<');
+    let thrown;
+    try {
+      generateDocs.createXmirHtmlBlock(bad);
+    } catch (error) {
+      thrown = error;
+    }
+    assert.ok(thrown.cause instanceof Error, 'the wrapper must keep the original XSL error as its cause');
+    done();
+  });
+  /**
+   * Tests that the original error survives to the top of the docs command,
+   * rather than being dropped by the outer catch block.
+   * @return {Promise} of the docs command run against a broken XMIR
+   */
+  it('surfaces the original error as the cause when docs fails', async () => {
+    const sample = path.join(parsed, 'pkg');
+    fs.mkdirSync(sample, {recursive: true});
+    fs.writeFileSync(path.join(sample, 'bad.xmir'), 'not valid xmir <<<');
+    let thrown;
+    try {
+      await generateDocs({target: home, sources: path.resolve(home, 'src')});
+    } catch (error) {
+      thrown = error;
+    }
+    assert.ok(thrown.cause instanceof Error, 'docs must surface the original XSL error as its cause');
+  });
+  /**
+   * Tests that the wrapper message is derived from the original error,
+   * so the failure text is not lost alongside the cause.
+   * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
+   */
+  it('embeds the original error text in the wrapper message', (done) => {
+    const bad = path.join(parsed, 'bad.xmir');
+    fs.writeFileSync(bad, 'not valid xmir <<<');
+    let thrown;
+    try {
+      generateDocs.createXmirHtmlBlock(bad);
+    } catch (error) {
+      thrown = error;
+    }
+    assert.ok(
+      thrown.message.includes(thrown.cause.message),
+      'the wrapper message must embed the original error text'
+    );
+    done();
+  });
 });


### PR DESCRIPTION
`createXmirHtmlBlock` in `src/commands/docs.js` wrapped a failure with `new Error(msg, error)`. The second `Error` argument must be an options object; a raw error is ignored, so `.cause` was never set and the original SaxonJS/XSLT error and its stack were silently discarded. A user whose `docs` run fails then sees only the wrapper message with no indication of where in the transform it went wrong.

Passing `{cause: error}` fixes it, matching the pattern already used in `normalize.js` and `jdk.js`, and lets Node print the nested `[cause]` stack when the failure is uncaught.

Tests cover three angles: the helper keeps the original error as `.cause`, that cause survives to the top of the `docs` command through the outer catch, and the wrapper message still embeds the original error text.

Verified: `npx mocha test/commands/test_docs.js` 12/12 passing, `npx eslint .` clean.

Closes #1089.