### PR TITLE
fix: add verifyJavac check to dataize.js (#1087)

### DIFF
--- a/src/commands/java/dataize.js
+++ b/src/commands/java/dataize.js
@@ -5,7 +5,7 @@
 
 const path = require('path');
 const {spawn} = require('node:child_process');
-const verifyJavac = require('../verify_javac');
+const verifyJavac = require('../../verify_javac');
 /**
  * Runs the single executable binary.
  * @param {String} obj - Name of object to dataize

--- a/src/commands/java/dataize.js
+++ b/src/commands/java/dataize.js
@@ -5,6 +5,7 @@
 
 const path = require('path');
 const {spawn} = require('node:child_process');
+const verifyJavac = require('../../verify_javac'); // ← добавить
 
 /**
  * Runs the single executable binary.
@@ -13,6 +14,7 @@ const {spawn} = require('node:child_process');
  * @param {Object} opts - All options
  */
 module.exports = function(obj, args, opts) {
+  verifyJavac(); // ← добавить
   const params = [
     '-Dfile.encoding=UTF-8',
     `-Xss${opts.stack}`,

--- a/src/commands/java/dataize.js
+++ b/src/commands/java/dataize.js
@@ -13,7 +13,7 @@ const verifyJavac = require('../../verify_javac');
  * @param {Object} opts - All options
  */
 module.exports = function(obj, args, opts) {
-  verifyJavac(); // ← добавить
+  verifyJavac();
   const params = [
     '-Dfile.encoding=UTF-8',
     `-Xss${opts.stack}`,

--- a/src/commands/java/dataize.js
+++ b/src/commands/java/dataize.js
@@ -5,8 +5,7 @@
 
 const path = require('path');
 const {spawn} = require('node:child_process');
-const verifyJavac = require('../../verify_javac'); // ← добавить
-
+const verifyJavac = require('../../verify_javac'); 
 /**
  * Runs the single executable binary.
  * @param {String} obj - Name of object to dataize

--- a/src/commands/java/dataize.js
+++ b/src/commands/java/dataize.js
@@ -5,7 +5,7 @@
 
 const path = require('path');
 const {spawn} = require('node:child_process');
-const verifyJavac = require('../../verify_javac'); 
+const verifyJavac = require('../verify_javac');
 /**
  * Runs the single executable binary.
  * @param {String} obj - Name of object to dataize

--- a/test/commands/java/test_dataize.js
+++ b/test/commands/java/test_dataize.js
@@ -1,15 +1,12 @@
-const dataize = require('../../../src/commands/java/dataize');
-const verifyJavac = require('../../../src/verify_javac');
-
-jest.mock('../../../src/verify_javac');
-
+const dataize = require('../src/commands/java/dataize');
+const verifyJavac = require('../src/verify_javac');
+jest.mock('../src/verify_javac');
 describe('dataize', () => {
   it('calls verifyJavac', () => {
     jest.spyOn(require('child_process'), 'spawn').mockImplementation(() => ({
       on: jest.fn()
     }));
-
-    dataize('foo', [], {target: '.', stack: '64M', heap: '256M'});
+    dataize('foo', [], { target: '.', stack: '64M', heap: '256M' });
     expect(verifyJavac).toHaveBeenCalled();
   });
-});D
+});

--- a/test/commands/java/test_dataize.js
+++ b/test/commands/java/test_dataize.js
@@ -1,3 +1,7 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
 const dataize = require('../src/commands/java/dataize');
 const verifyJavac = require('../../src/verify_javac');
 

--- a/test/commands/java/test_dataize.js
+++ b/test/commands/java/test_dataize.js
@@ -2,10 +2,10 @@
  * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
  * SPDX-License-Identifier: MIT
  */
-const dataize = require('../src/commands/java/dataize');
-const verifyJavac = require('../../src/verify_javac');
+const dataize = require('../../../src/commands/java/dataize');
+const verifyJavac = require('../../../src/verify_javac');
 
-jest.mock('../../src/verify_javac');
+jest.mock('../../../src/verify_javac');
 
 describe('dataize', () => {
   it('calls verifyJavac', () => {

--- a/test/commands/java/test_dataize.js
+++ b/test/commands/java/test_dataize.js
@@ -1,0 +1,15 @@
+const dataize = require('../../../src/commands/java/dataize');
+const verifyJavac = require('../../../src/verify_javac');
+
+jest.mock('../../../src/verify_javac');
+
+describe('dataize', () => {
+  it('calls verifyJavac', () => {
+    jest.spyOn(require('child_process'), 'spawn').mockImplementation(() => ({
+      on: jest.fn()
+    }));
+
+    dataize('foo', [], {target: '.', stack: '64M', heap: '256M'});
+    expect(verifyJavac).toHaveBeenCalled();
+  });
+});D

--- a/test/commands/java/test_dataize.js
+++ b/test/commands/java/test_dataize.js
@@ -11,9 +11,7 @@ describe('dataize', () => {
   it('calls verifyJavac', () => {
     jest.spyOn(require('child_process'), 'spawn')
       .mockImplementation(() => ({ on: jest.fn() }));
-
     dataize('foo', [], { target: '.', stack: '64M', heap: '256M' });
-
     expect(verifyJavac).toHaveBeenCalled();
   });
 });

--- a/test/commands/java/test_dataize.js
+++ b/test/commands/java/test_dataize.js
@@ -1,12 +1,15 @@
 const dataize = require('../src/commands/java/dataize');
-const verifyJavac = require('../src/verify_javac');
-jest.mock('../src/verify_javac');
+const verifyJavac = require('../../src/verify_javac');
+
+jest.mock('../../src/verify_javac');
+
 describe('dataize', () => {
   it('calls verifyJavac', () => {
-    jest.spyOn(require('child_process'), 'spawn').mockImplementation(() => ({
-      on: jest.fn()
-    }));
+    jest.spyOn(require('child_process'), 'spawn')
+      .mockImplementation(() => ({ on: jest.fn() }));
+
     dataize('foo', [], { target: '.', stack: '64M', heap: '256M' });
+
     expect(verifyJavac).toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Fixes #1087

Added `verifyJavac()` call at the beginning of the `dataize` function to provide a friendly error message when Java is not installed, matching the behavior of other Java-related commands (`compile.js`, `link.js`, `test.js`, `pipeline.js`).

Also added a test for this case in `test/commands/java/test_dataize.js`.