### PR TITLE
fix: validate --object format in test command

### DIFF
--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -20,7 +20,6 @@ module.exports = function(opts, maven = mvnw) {
     `-Dheap-size=${opts.heap}`,
   ];
   if (opts.object) {
-    // Проверка, что есть хотя бы одна точка
     if (!opts.object.includes('.')) {
       throw new Error(`Invalid --object format: expected object.method (or pkg.object.method), got "${opts.object}"`);
     }

--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -20,9 +20,9 @@ module.exports = function(opts, maven = mvnw) {
     `-Dheap-size=${opts.heap}`,
   ];
   if (opts.object) {
-    if (!opts.object.includes('.')) {
-      throw new Error(`Invalid --object format: expected object.method (or pkg.object.method), got "${opts.object}"`);
-    }
+    if (opts.object.split('.').filter(Boolean).length < 2) {
+  throw new Error(`Invalid --object format: expected object.method (or pkg.object.method), got "${opts.object}"`);
+}
     const parts = opts.object.split('.');
     const method = parts.pop().replace(/-/g, '_');
     const obj = parts.pop().replace(/-/g, '_');

--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -21,14 +21,18 @@ module.exports = function(opts, maven = mvnw) {
   ];
   if (opts.object) {
     if (opts.object.split('.').filter(Boolean).length < 2) {
-  throw new Error(`Invalid --object format: expected object.method (or pkg.object.method), got "${opts.object}"`);
-}
+      throw new Error(
+        `Invalid --object format: expected object.method (or pkg.object.method), got "${opts.object}"`
+      );
+    }
     const parts = opts.object.split('.');
     const method = parts.pop().replace(/-/g, '_');
     const obj = parts.pop().replace(/-/g, '_');
     const pkg = parts.map((p) => `EO${p.replace(/-/g, '_')}`).join('.');
     const cls = `EO${obj}*Test`;
-    args.push(`-Dtest=${pkg ? `org.eolang.${pkg}.${cls}` : `org.eolang.${cls}`}#${method}`);
+    args.push(
+      `-Dtest=${pkg ? `org.eolang.${pkg}.${cls}` : `org.eolang.${cls}`}#${method}`
+    );
   }
   return maven(args.concat(flags(opts)));
 };

--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -20,6 +20,10 @@ module.exports = function(opts, maven = mvnw) {
     `-Dheap-size=${opts.heap}`,
   ];
   if (opts.object) {
+    // Проверка, что есть хотя бы одна точка
+    if (!opts.object.includes('.')) {
+      throw new Error(`Invalid --object format: expected object.method (or pkg.object.method), got "${opts.object}"`);
+    }
     const parts = opts.object.split('.');
     const method = parts.pop().replace(/-/g, '_');
     const obj = parts.pop().replace(/-/g, '_');

--- a/test/commands/java/test_test.js
+++ b/test/commands/java/test_test.js
@@ -9,8 +9,16 @@ describe('java/test', () => {
   it('builds -Dtest filter from --object with package', async () => {
     let captured;
     await test(
-      {stack: '64M', heap: '256M', sources: 'src', target: 'target', object: 'foo.app.works-fine'},
-      (args) => { captured = args; }
+      {
+        stack: '64M',
+        heap: '256M',
+        sources: 'src',
+        target: 'target',
+        object: 'foo.app.works-fine',
+      },
+      (args) => {
+        captured = args;
+      }
     );
     assert.ok(
       captured.includes('-Dtest=org.eolang.EOfoo.EOapp*Test#works_fine'),
@@ -21,8 +29,16 @@ describe('java/test', () => {
   it('builds -Dtest filter from --object without package', async () => {
     let captured;
     await test(
-      {stack: '64M', heap: '256M', sources: 'src', target: 'target', object: 'app.works-fine'},
-      (args) => { captured = args; }
+      {
+        stack: '64M',
+        heap: '256M',
+        sources: 'src',
+        target: 'target',
+        object: 'app.works-fine',
+      },
+      (args) => {
+        captured = args;
+      }
     );
     assert.ok(
       captured.includes('-Dtest=org.eolang.EOapp*Test#works_fine'),
@@ -33,8 +49,15 @@ describe('java/test', () => {
   it('omits -Dtest when --object is not provided', async () => {
     let captured;
     await test(
-      {stack: '64M', heap: '256M', sources: 'src', target: 'target'},
-      (args) => { captured = args; }
+      {
+        stack: '64M',
+        heap: '256M',
+        sources: 'src',
+        target: 'target',
+      },
+      (args) => {
+        captured = args;
+      }
     );
     assert.ok(
       !captured.some((a) => a.startsWith('-Dtest=')),
@@ -42,41 +65,62 @@ describe('java/test', () => {
     );
   });
 
-  it('throws on single-segment object', () => {
-    assert.throws(
-      () => test({
+  it('passes execution options to Maven', async () => {
+    let captured;
+    await test(
+      {
         stack: '64M',
         heap: '256M',
         sources: 'src',
         target: 'target',
-        object: 'app',
-      }),
+        batch: true,
+      },
+      (args, target, batch) => {
+        captured = {args, target, batch};
+      }
+    );
+    assert.strictEqual(captured.target, 'target');
+    assert.strictEqual(captured.batch, true);
+  });
+
+  it('throws on single-segment object', () => {
+    assert.throws(
+      () =>
+        test({
+          stack: '64M',
+          heap: '256M',
+          sources: 'src',
+          target: 'target',
+          object: 'app',
+        }),
       /Invalid --object format/
     );
   });
 
   it('throws on trailing dot', () => {
     assert.throws(
-      () => test({
-        stack: '64M',
-        heap: '256M',
-        sources: 'src',
-        target: 'target',
-        object: 'app.',
-      }),
+      () =>
+        test({
+          stack: '64M',
+          heap: '256M',
+          sources: 'src',
+          target: 'target',
+          object: 'app.',
+        }),
       /Invalid --object format/
     );
   });
 
   it('throws on leading dot', () => {
     assert.throws(
-      () => test({
-        stack: '64M',
-        heap: '256M',
-        sources: 'src',
-        target: 'target',
-        object: '.works-fine',
-      }),
+      () =>
+        test({
+          stack: '64M',
+          heap: '256M',
+          sources: 'src',
+          target: 'target',
+          object: '.works-fine',
+        }),
       /Invalid --object format/
     );
   });

--- a/test/commands/java/test_test.js
+++ b/test/commands/java/test_test.js
@@ -17,6 +17,7 @@ describe('java/test', () => {
       `expected -Dtest=org.eolang.EOfoo.EOapp*Test#works_fine, got: ${captured}`
     );
   });
+
   it('builds -Dtest filter from --object without package', async () => {
     let captured;
     await test(
@@ -28,6 +29,7 @@ describe('java/test', () => {
       `expected -Dtest=org.eolang.EOapp*Test#works_fine, got: ${captured}`
     );
   });
+
   it('omits -Dtest when --object is not provided', async () => {
     let captured;
     await test(
@@ -37,6 +39,45 @@ describe('java/test', () => {
     assert.ok(
       !captured.some((a) => a.startsWith('-Dtest=')),
       `expected no -Dtest arg, got: ${captured}`
+    );
+  });
+
+  it('throws on single-segment object', () => {
+    assert.throws(
+      () => test({
+        stack: '64M',
+        heap: '256M',
+        sources: 'src',
+        target: 'target',
+        object: 'app',
+      }),
+      /Invalid --object format/
+    );
+  });
+
+  it('throws on trailing dot', () => {
+    assert.throws(
+      () => test({
+        stack: '64M',
+        heap: '256M',
+        sources: 'src',
+        target: 'target',
+        object: 'app.',
+      }),
+      /Invalid --object format/
+    );
+  });
+
+  it('throws on leading dot', () => {
+    assert.throws(
+      () => test({
+        stack: '64M',
+        heap: '256M',
+        sources: 'src',
+        target: 'target',
+        object: '.works-fine',
+      }),
+      /Invalid --object format/
     );
   });
 });

--- a/test/commands/java/test_test.js
+++ b/test/commands/java/test_test.js
@@ -25,7 +25,6 @@ describe('java/test', () => {
       `expected -Dtest=org.eolang.EOfoo.EOapp*Test#works_fine, got: ${captured}`
     );
   });
-
   it('builds -Dtest filter from --object without package', async () => {
     let captured;
     await test(
@@ -45,7 +44,6 @@ describe('java/test', () => {
       `expected -Dtest=org.eolang.EOapp*Test#works_fine, got: ${captured}`
     );
   });
-
   it('omits -Dtest when --object is not provided', async () => {
     let captured;
     await test(
@@ -64,7 +62,6 @@ describe('java/test', () => {
       `expected no -Dtest arg, got: ${captured}`
     );
   });
-  
   it('passes execution options to Maven', async () => {
     let captured;
     await test(
@@ -82,7 +79,6 @@ describe('java/test', () => {
     assert.strictEqual(captured.target, 'target');
     assert.strictEqual(captured.batch, true);
   });
-
   it('throws on single-segment object', () => {
     assert.throws(
       () =>
@@ -96,7 +92,6 @@ describe('java/test', () => {
       /Invalid --object format/
     );
   });
-
   it('throws on trailing dot', () => {
     assert.throws(
       () =>
@@ -110,7 +105,6 @@ describe('java/test', () => {
       /Invalid --object format/
     );
   });
-
   it('throws on leading dot', () => {
     assert.throws(
       () =>


### PR DESCRIPTION
Fixes https://github.com/objectionary/eoc/issues/1086

Added validation to ensure --object value contains at least one dot
before splitting. If not, throws a clear error message instead of
crashing with an unhandled TypeError.