### PR TITLE
Fail fast in java dataize when the JDK is missing

### DIFF
--- a/src/commands/java/dataize.js
+++ b/src/commands/java/dataize.js
@@ -5,14 +5,17 @@
 
 const path = require('path');
 const {spawn} = require('node:child_process');
+const {verifyJavac} = require('../../jdk');
 
 /**
  * Runs the single executable binary.
  * @param {String} obj - Name of object to dataize
  * @param {Array} args - Arguments
  * @param {Object} opts - All options
+ * @param {Function} [exec] - Optional command runner for the JDK check
  */
-module.exports = function(obj, args, opts) {
+module.exports = function(obj, args, opts, exec) {
+  verifyJavac(exec);
   const params = [
     '-Dfile.encoding=UTF-8',
     `-Xss${opts.stack}`,

--- a/test/commands/test_dataize.js
+++ b/test/commands/test_dataize.js
@@ -6,6 +6,7 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
+const dataize = require('../../src/commands/java/dataize');
 const {runSync, parserVersion, homeTag, weAreOnline} = require('../helpers'),
 
   options = [
@@ -81,5 +82,42 @@ describe('dataize', () => {
     ]);
     assert(stdout.includes('Hooray'), stdout);
     done();
+  });
+});
+
+describe('dataize/java', () => {
+  it('fails fast with a clear message when javac is not on the PATH', () => {
+    const missing = () => {
+      const cause = new Error('spawnSync javac ENOENT');
+      cause.code = 'ENOENT';
+      throw cause;
+    };
+    assert.throws(
+      () => dataize('main.foo', [], {target: '.', stack: '64M', heap: '256M'}, missing),
+      /javac/,
+      'dataize does not fail fast with a clear javac message when the JDK is missing'
+    );
+  });
+  it('fails fast and mentions the JDK when javac exits non-zero', () => {
+    const broken = () => {
+      const cause = new Error('Command failed: javac -version');
+      cause.status = 127;
+      throw cause;
+    };
+    assert.throws(
+      () => dataize('main.foo', [], {target: '.', stack: '64M', heap: '256M'}, broken),
+      /JDK/,
+      'dataize does not mention the JDK when javac exits non-zero'
+    );
+  });
+  it('surfaces the underlying failure when javac cannot be executed', () => {
+    const denied = () => {
+      throw new Error('permission denied while probing javac');
+    };
+    assert.throws(
+      () => dataize('main.foo', [], {target: '.', stack: '64M', heap: '256M'}, denied),
+      /permission denied while probing javac/,
+      'dataize hides the underlying reason why javac could not be executed'
+    );
   });
 });


### PR DESCRIPTION
The `dataize` command was the only Java command that spawned a JVM without first checking that a JDK is present. When `java` was missing from the PATH, the spawned child emitted an `'error'` event with no listener, so Node crashed the whole process with an internal stack trace instead of a readable message.

This makes `dataize` verify the JDK up front with `verifyJavac()`, exactly like its siblings `compile`, `link`, `test`, and `pipeline`. A missing or broken toolchain now fails fast with the same actionable "install a JDK" guidance the rest of the toolchain already gives, before any subprocess is spawned. The command runner is injectable so the behaviour can be exercised without touching a real environment.

Tests cover three failure modes of the check: `javac` absent from the PATH, `javac` exiting non-zero, and the underlying reason being surfaced.

Closes #1087
