### PR TITLE
Enable internal debug logging with --debug

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -95,7 +95,10 @@ function canonicalLanguage(value) {
   return canonical;
 }
 
-if (process.argv.includes('--verbose')) {
+if (
+  process.argv.includes('--verbose') ||
+  process.argv.includes('--debug')
+) {
   tinted.enable('debug');
   console.debug('Debug output is turned ON');
 }

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -20,6 +20,18 @@ describe('eoc', () => {
     assert(stdout.includes(version.when));
     done();
   });
+  it('enables internal debug logging with --debug', (done) => {
+    const stdout = runSync(['--debug', '--version']);
+    assert(
+      stdout.includes('Debug output is turned ON'),
+      stdout
+    );
+    assert(
+      stdout.includes('EO parser'),
+      stdout
+    );
+    done();
+  });
   it('can get commands description from eoc as a module', (done) => {
     const commandsDescriptionList = require('../src/eoc').commandsDescription();
     assert(commandsDescriptionList.length > 0,"commandsDescriptionList should have more then one element");


### PR DESCRIPTION
Closes #1100.

The `--debug` option was forwarded to Maven but did not enable EOC's
internal debug logger. This change enables internal debug logging when
either `--verbose` or `--debug` is provided.

A regression test was added to verify that `--debug` prints EOC's internal
debug messages.

Tests:
- `npx mocha test/test_eoc.js --timeout 1200000`
- `npm test` — 144 passing, 10 pending
- `npx grunt`