### PR TITLE
Closes #1103. Check pinned version before audit

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -166,6 +166,7 @@ program.hook('preAction', (command) => {
 program.command('audit')
   .description('Inspect all packages and report their status')
   .action(async (str, opts) => {
+    pin(program.opts());
     await coms().audit(program.opts());
   });
 

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -250,6 +250,13 @@ describe('eoc', () => {
 
 describe('eoc', () => {
   before(weAreOnline);
+  it('fails audit due to version mismatch if different --pin provided', (done) => {
+    assert.throws(
+      () => { runSync(['--pin=29.9.4', 'audit']); },
+      /Version mismatch: you are running eoc [0-9]+\.[0-9]+\.[0-9]+, but --pin option requires 29.9.4/
+    );
+    done();
+  });
   it('cleans successfully when if --pin not provided', (done) => {
     const stdout = runSync(['clean']);
     assert(stdout.includes("The directory .eoc does not exist, no need to delete it"));


### PR DESCRIPTION
Closes #1103.

The `audit` command ignored the global `--pin` option and continued
executing when the pinned version did not match the current EOC version.

This change checks the pinned version before running `audit` and adds
a regression test for the mismatched version case.

Tests:
- `npx mocha test/test_eoc.js --timeout 1200000` — 28 passing
- `npm test` — 150 passing, 10 pending
- `npx grunt` — 150 passing, 10 pending