### PR TITLE
Closes #1106. Guard clean against symbolic links

### DIFF
--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -9,18 +9,32 @@ const path = require('path');
 const os = require('os');
 
 /**
- * Refuses, by throwing, to delete a directory that is the current
+ * Resolves symbolic links in the parent part of a path.
+ * @param {String} target - Path to canonicalize
+ * @return {String} Path with its parent resolved
+ */
+function canonical(target) {
+  const parent = path.dirname(target);
+  return fs.existsSync(parent)
+    ? path.join(fs.realpathSync(parent), path.basename(target))
+    : target;
+}
+
+/**
+ * Refuses, by throwing, to delete a directory that resolves to the current
  * working directory, an ancestor of it, or the user's home directory;
- * otherwise returns it unchanged, so the guard cannot be skipped or
- * reordered away from the value it protects.
+ * otherwise returns the original target unchanged, so the guard cannot be
+ * skipped or reordered away from the value it protects.
  * @param {String} target - Resolved absolute path of the directory to delete
- * @return {String} The same target, once confirmed safe to delete
+ * @return {String} The original target, once confirmed safe to delete
  */
 function guarded(target) {
-  const cwd = process.cwd();
-  const route = path.relative(target, cwd);
+  const actual = canonical(target);
+  const cwd = fs.realpathSync(process.cwd());
+  const home = fs.realpathSync(os.homedir());
+  const route = path.relative(actual, cwd);
   const encloses = route === '' || (!route.startsWith('..') && !path.isAbsolute(route));
-  if (encloses || target === os.homedir()) {
+  if (encloses || actual === home) {
     throw new Error(
       `Refusing to delete ${rel(target)}: it is the current directory, an ancestor of it, or the home directory`
     );

--- a/test/commands/test_clean.js
+++ b/test/commands/test_clean.js
@@ -65,6 +65,36 @@ describe('clean', () => {
     assert(fs.existsSync(home), 'the current directory must not be deleted');
     done();
   });
+  it('refuses to delete the current directory through a symbolic link', (done) => {
+    const {spawnSync} = require('child_process');
+    const home = path.resolve(testDir, 'refuses-symlink-cwd'),
+      real = path.resolve(home, 'real'),
+      link = path.resolve(home, 'link'),
+      type = process.platform === 'win32' ? 'junction' : 'dir';
+    fs.rmSync(home, {recursive: true, force: true});
+    fs.mkdirSync(real, {recursive: true});
+    fs.symlinkSync(home, link, type);
+    const s = spawnSync(
+      'node',
+      [
+        path.resolve('./src/eoc.js'),
+        '--target',
+        path.resolve(link, 'real'),
+        'clean'
+      ],
+      {cwd: real}
+    );
+    assert(s.status !== 0, `${s.stdout.toString()}\n${s.stderr.toString()}`);
+    assert(
+      s.stderr.toString().includes('Refusing to delete'),
+      s.stderr.toString()
+    );
+    assert(
+      fs.existsSync(real),
+      'the current directory must not be deleted through a symbolic link'
+    );
+    done();
+  });
   it('refuses to delete an ancestor of the current working directory', (done) => {
     const {spawnSync} = require('child_process');
     const home = path.resolve(testDir, 'refuses-ancestor'),


### PR DESCRIPTION
Closes #1106.

The `clean` command compared lexical paths when checking whether the
target was the current working directory, one of its ancestors, or the
home directory. This allowed the protection to be bypassed through a
symbolic link.

This change resolves symbolic links in the target's parent path before
performing the safety comparison. The original target remains unchanged
for the actual deletion.

A regression test verifies that `clean` refuses to delete the current
working directory through a symbolic link.

Tests:
- `npx mocha test/commands/test_clean.js --timeout 1200000` — 6 passing
- `npm test` — 150 passing, 10 pending
- `npx grunt` — 150 passing, 10 pending