### PR TITLE
Closes #1108. Exclude target from recursive copying

### DIFF
--- a/src/commands/normalize.js
+++ b/src/commands/normalize.js
@@ -33,7 +33,7 @@ module.exports = function(opts) {
   const sources = path.resolve(opts.sources);
   const target = path.resolve(opts.target);
   return elapsed(async (tracked) => {
-    copyDir(sources, path.join(target, 'before-normalize'), '.eo');
+    copyDir(sources, path.join(target, 'before-normalize'), '.eo', target);
     const parsed = path.join(target, '1-parse');
     const normed = path.join(target, 'xmir-normalized');
     const xmirs = findFiles(parsed, '.xmir');

--- a/src/files.js
+++ b/src/files.js
@@ -43,15 +43,17 @@ function saveFile(dir, name, content) {
  * @param {string} src - Source directory
  * @param {string} dst - Destination directory
  * @param {string} ext - File extension filter (e.g. '.eo'), or empty for all files
+ * @param {string} [excluded] - Directory to exclude from recursive traversal
  */
-function copyDir(src, dst, ext) {
+function copyDir(src, dst, ext, excluded) {
   if (!fs.existsSync(src)) {return;}
+  if (excluded && path.resolve(src) === path.resolve(excluded)) {return;}
   fs.mkdirSync(dst, {recursive: true});
   for (const entry of fs.readdirSync(src, {withFileTypes: true})) {
     const source = path.join(src, entry.name);
     const dest = path.join(dst, entry.name);
     if (entry.isDirectory()) {
-      copyDir(source, dest, ext);
+      copyDir(source, dest, ext, excluded);
     } else if (!ext || entry.name.endsWith(ext)) {
       fs.copyFileSync(source, dest);
     }

--- a/test/test_files.js
+++ b/test/test_files.js
@@ -1,0 +1,37 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+const {copyDir} = require('../src/files');
+
+describe('files', () => {
+  it('excludes a nested target from recursive copying', done => {
+    const home = path.resolve('temp/test-files/nested-target'),
+      target = path.resolve(home, '.eoc'),
+      backup = path.resolve(target, 'before-normalize');
+    fs.rmSync(home, {recursive: true, force: true});
+    fs.mkdirSync(home, {recursive: true});
+    fs.writeFileSync(
+      path.resolve(home, 'simple.eo'),
+      '# sample\n[] > simple\n'
+    );
+    try {
+      copyDir(home, backup, '.eo', target);
+      assert(
+        fs.existsSync(path.resolve(backup, 'simple.eo')),
+        'EO source file must be copied into before-normalize'
+      );
+      assert(
+        !fs.existsSync(path.resolve(backup, path.basename(target))),
+        'the excluded target must not be copied into itself'
+      );
+    } finally {
+      fs.rmSync(home, {recursive: true, force: true});
+    }
+    done();
+  });
+});


### PR DESCRIPTION
Closes #1108.

The `normalize` command copied source files into `target/before-normalize`.
When the target directory was located inside the sources directory, as with
the default `.eoc` target, recursive copying entered the newly created target
and repeatedly copied it into itself until failing with `ENAMETOOLONG`.

This change allows `copyDir()` to exclude a directory from recursive
traversal. The `normalize` command excludes its target directory while
creating the backup.

A regression test verifies that a nested target is not recursively copied
into itself.

Tests:
- `npx mocha test/test_files.js --timeout 120000` — 1 passing
- `npm test` — 150 passing, 10 pending
- `npx grunt` — 150 passing, 10 pending