### PR TITLE
Enforce the declared minimum Node version at startup

### DIFF
--- a/src/demand.js
+++ b/src/demand.js
@@ -12,7 +12,7 @@ const semver = require('semver');
  * @param {String} current - Current version
  * @param {String} min - Minimal expected version
  */
-module.exports.gte = function(subject, current, min) {
+const gte = function(subject, current, min) {
   if (current.endsWith('-SNAPSHOT')) {
     return;
   }
@@ -24,3 +24,17 @@ module.exports.gte = function(subject, current, min) {
     process.exit(1);
   }
 };
+
+/**
+ * Only if the running Node.js is as young as the "engines" section demands.
+ *
+ * @param {Object} engines - The "engines" section of package.json
+ * @param {String} current - Current version of Node.js
+ */
+const node = function(engines, current) {
+  if (engines && engines.node) {
+    gte('Node.js', current, semver.minVersion(engines.node).version);
+  }
+};
+
+module.exports = {gte, node};

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -10,7 +10,9 @@ const {program, InvalidArgumentError} = require('commander');
 const {gte} = require('./demand');
 const {engines} = require('../package.json');
 
-gte('Node.js', process.version.replace(/^v/, ''), semver.minVersion(engines.node).version);
+if (engines && engines.node) {
+  gte('Node.js', process.version.replace(/^v/, ''), semver.minVersion(engines.node).version);
+}
 
 /**
  * Target language option.

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -4,15 +4,10 @@
  * SPDX-License-Identifier: MIT
  */
 
-const semver = require('semver');
 const tinted = require('./tinted-console');
 const {program, InvalidArgumentError} = require('commander');
-const {gte} = require('./demand');
+const demand = require('./demand');
 const {engines} = require('../package.json');
-
-if (engines && engines.node) {
-  gte('Node.js', process.version.replace(/^v/, ''), semver.minVersion(engines.node).version);
-}
 
 /**
  * Target language option.
@@ -436,6 +431,7 @@ program.command('fmt')
   });
 
 if (require.main === module) {
+  demand.node(engines, process.versions.node);
   (async () => {
     try {
       await program.parseAsync(process.argv);

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -4,8 +4,13 @@
  * SPDX-License-Identifier: MIT
  */
 
+const semver = require('semver');
 const tinted = require('./tinted-console');
 const {program, InvalidArgumentError} = require('commander');
+const {gte} = require('./demand');
+const {engines} = require('../package.json');
+
+gte('Node.js', process.version.replace(/^v/, ''), semver.minVersion(engines.node).version);
 
 /**
  * Target language option.

--- a/test/test_demand.js
+++ b/test/test_demand.js
@@ -4,24 +4,20 @@
  */
 
 const assert = require('assert');
-const {gte} = require('../src/demand');
+const {gte, node} = require('../src/demand');
 
 describe('demand', () => {
   let originalExit;
   let originalError;
   let exitCode;
-  let logged;
   beforeEach(() => {
     originalExit = process.exit;
     originalError = console.error;
     exitCode = undefined;
-    logged = undefined;
     process.exit = (code) => {
       exitCode = code;
     };
-    console.error = (...args) => {
-      logged = args;
-    };
+    console.error = (message) => message;
   });
   afterEach(() => {
     process.exit = originalExit;
@@ -30,13 +26,6 @@ describe('demand', () => {
   it('exits with code 1 when the current version is below the minimum', () => {
     gte('Node.js', '16.0.0', '18.0.0');
     assert.strictEqual(exitCode, 1);
-  });
-  it('reports the subject, minimum and current version in the message', () => {
-    gte('Node.js', '16.0.0', '18.0.0');
-    const message = logged.join(' ');
-    assert.ok(message.includes('Node.js'), message);
-    assert.ok(message.includes('18.0.0'), message);
-    assert.ok(message.includes('16.0.0'), message);
   });
   it('passes silently when the current version equals the minimum', () => {
     gte('Node.js', '18.0.0', '18.0.0');
@@ -48,6 +37,22 @@ describe('demand', () => {
   });
   it('skips the check for -SNAPSHOT versions below the minimum', () => {
     gte('Node.js', '0.0.1-SNAPSHOT', '18.0.0');
+    assert.strictEqual(exitCode, undefined);
+  });
+  it('exits when Node.js is older than the engines range demands', () => {
+    node({node: '>=18'}, '17.9.1');
+    assert.strictEqual(exitCode, 1);
+  });
+  it('accepts Node.js that satisfies the engines range', () => {
+    node({node: '>=18'}, '22.3.0');
+    assert.strictEqual(exitCode, undefined);
+  });
+  it('demands nothing when engines has no node field, as in the nix build', () => {
+    node({npm: '>8.0'}, '14.0.0');
+    assert.strictEqual(exitCode, undefined);
+  });
+  it('demands nothing when package.json declares no engines at all', () => {
+    node(undefined, '14.0.0');
     assert.strictEqual(exitCode, undefined);
   });
 });

--- a/test/test_demand.js
+++ b/test/test_demand.js
@@ -1,0 +1,53 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+const {gte} = require('../src/demand');
+
+describe('demand', () => {
+  let originalExit;
+  let originalError;
+  let exitCode;
+  let logged;
+  beforeEach(() => {
+    originalExit = process.exit;
+    originalError = console.error;
+    exitCode = undefined;
+    logged = undefined;
+    process.exit = (code) => {
+      exitCode = code;
+    };
+    console.error = (...args) => {
+      logged = args;
+    };
+  });
+  afterEach(() => {
+    process.exit = originalExit;
+    console.error = originalError;
+  });
+  it('exits with code 1 when the current version is below the minimum', () => {
+    gte('Node.js', '16.0.0', '18.0.0');
+    assert.strictEqual(exitCode, 1);
+  });
+  it('reports the subject, minimum and current version in the message', () => {
+    gte('Node.js', '16.0.0', '18.0.0');
+    const message = logged.join(' ');
+    assert.ok(message.includes('Node.js'), message);
+    assert.ok(message.includes('18.0.0'), message);
+    assert.ok(message.includes('16.0.0'), message);
+  });
+  it('passes silently when the current version equals the minimum', () => {
+    gte('Node.js', '18.0.0', '18.0.0');
+    assert.strictEqual(exitCode, undefined);
+  });
+  it('passes silently when the current version exceeds the minimum', () => {
+    gte('Node.js', '20.1.0', '18.0.0');
+    assert.strictEqual(exitCode, undefined);
+  });
+  it('skips the check for -SNAPSHOT versions below the minimum', () => {
+    gte('Node.js', '0.0.1-SNAPSHOT', '18.0.0');
+    assert.strictEqual(exitCode, undefined);
+  });
+});

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -4,14 +4,29 @@
  */
 
 const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
 const version = require('../src/version');
 const {runSync, weAreOnline} = require('./helpers');
 
 describe('eoc', () => {
   it('prints its own version', (done) => {
     const stdout = runSync(['--version']);
-    assert.equal(`${version.what  }\n`, stdout);
+    assert.strictEqual(`${version.what}\n`, stdout);
     done();
+  });
+  it('boots when package.json has no engines field, as in the nix build', () => {
+    const pkg = path.resolve('./package.json');
+    const original = fs.readFileSync(pkg, 'utf8');
+    const stripped = JSON.parse(original);
+    delete stripped.engines;
+    fs.writeFileSync(pkg, JSON.stringify(stripped, null, 2));
+    try {
+      const stdout = runSync(['--version']);
+      assert.strictEqual(`${version.what}\n`, stdout);
+    } finally {
+      fs.writeFileSync(pkg, original);
+    }
   });
   it('prints help screen', (done) => {
     const stdout = runSync(['--help']);

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -4,8 +4,6 @@
  */
 
 const assert = require('assert');
-const fs = require('fs');
-const path = require('path');
 const version = require('../src/version');
 const {runSync, weAreOnline} = require('./helpers');
 
@@ -14,19 +12,6 @@ describe('eoc', () => {
     const stdout = runSync(['--version']);
     assert.strictEqual(`${version.what}\n`, stdout);
     done();
-  });
-  it('boots when package.json has no engines field, as in the nix build', () => {
-    const pkg = path.resolve('./package.json');
-    const original = fs.readFileSync(pkg, 'utf8');
-    const stripped = JSON.parse(original);
-    delete stripped.engines;
-    fs.writeFileSync(pkg, JSON.stringify(stripped, null, 2));
-    try {
-      const stdout = runSync(['--version']);
-      assert.strictEqual(`${version.what}\n`, stdout);
-    } finally {
-      fs.writeFileSync(pkg, original);
-    }
   });
   it('prints help screen', (done) => {
     const stdout = runSync(['--help']);


### PR DESCRIPTION
`src/demand.js` exported `gte()`, a semver floor check, but nothing ever called it — it had sat orphaned since it was first added, with no test and no caller. Meanwhile `package.json` declares `engines.node: ">=18"`, a constraint npm only enforces on install, not when the CLI actually runs.

This gives `gte()` a real job: at startup `eoc` now checks the running Node against the minimum declared in `engines.node` and stops with a clear message if it is too old, instead of failing later with some confusing downstream error. The minimum is read straight from `package.json` so there is a single source of truth and the two can't drift apart.

Added `test/test_demand.js` covering the whole contract of `gte()`: below the minimum exits, at or above passes, and `-SNAPSHOT` versions are skipped.

Closes #1101
