### PR TITLE
Closes #1111. Reject empty comment placeholder

### DIFF
--- a/src/commands/generate_comments.js
+++ b/src/commands/generate_comments.js
@@ -116,9 +116,12 @@ function generateDocumentation(inputCode, commentPlaceholder, chain) {
  * @return {Promise} of documentation generation task
  */
 module.exports = async function(opts) {
+  const commentPlaceholder = opts.comment_placeholder;
+  if (!commentPlaceholder) {
+    throw new Error('Comment placeholder must not be empty');
+  }
   const chain = constructChain(opts);
   const inputCode = readFileSync(opts.source, 'utf-8');
-  const commentPlaceholder = opts.comment_placeholder;
   const results = await generateDocumentation(
     inputCode,
     commentPlaceholder,

--- a/test/commands/test_generate_comments.js
+++ b/test/commands/test_generate_comments.js
@@ -21,6 +21,20 @@ describe('generate_comments', () => {
     (error) => error.message.includes('`nonexisting` provider is not supported.'));
     done();
   });
+  it('rejects an empty comment placeholder', () => {
+    const home = makeHome();
+    assert.throws(() =>
+      runSync([
+        'generate_comments',
+        '--provider=placeholder',
+        '--comment_placeholder',
+        '',
+        `--prompt_template=${makePromptFile(home, '')}`,
+        `--source=${makeInputFile(home, 'abc')}`]),
+    (error) => error.message.includes(
+      'Comment placeholder must not be empty'
+    ));
+  });
   it('fills output depending on the number of placeholders in the input code', (done) => {
     const home = makeHome();
     for (let placeholders = 0; placeholders < 3; ++placeholders) {


### PR DESCRIPTION
Closes #1111.

The `generate_comments` command previously accepted an empty
`--comment_placeholder` value.

The empty value was converted into a global regular expression, which
matched at every position in the input. As a result, the provider was
invoked multiple times even though the source contained no actual
placeholder.

This change rejects an empty comment placeholder before constructing the
provider chain or processing the input.

A regression test verifies that the command exits with an error when an
empty placeholder is provided.

Tests:
- `npx eslint src/commands/generate_comments.js test/commands/test_generate_comments.js`
- `npx mocha test/commands/test_generate_comments.js --timeout 1200000` — 6 passing
- `npm test` — 163 passing, 10 pending
- `npx grunt` — 163 passing, 10 pending