### PR TITLE
fix(#1086): validate short --object values

### DIFF
--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -22,6 +22,12 @@ module.exports = function(opts, maven = mvnw) {
   ];
   if (opts.object) {
     const parts = opts.object.split('.');
+    if (parts.length < 2) {
+      throw new Error(
+        `The --object value "${opts.object}" must include both object and test names, ` +
+        'for example "app.works-correctly"'
+      );
+    }
     const method = parts.pop().replace(/-/g, '_');
     const obj = parts.pop().replace(/-/g, '_');
     const pkg = parts.map((p) => `EO${p.replace(/-/g, '_')}`).join('.');

--- a/test/commands/java/test_test.js
+++ b/test/commands/java/test_test.js
@@ -56,4 +56,13 @@ describe('java/test', () => {
     assert.strictEqual(captured.target, 'target');
     assert.strictEqual(captured.batch, true);
   });
+  it('rejects --object values without both object and test names', () => {
+    assert.throws(
+      () => test(
+        {stack: '64M', heap: '256M', sources: 'src', target: 'target', object: 'simple'},
+        () => {}
+      ),
+      /must include both object and test names/
+    );
+  });
 });


### PR DESCRIPTION
Closes #1086.

## What was happening

`eoc test --object` assumed that the input always contained at least two dot-separated segments. Values like `simple` crashed later in the command flow instead of producing a helpful validation error.

## What changed

- validate `--object` before extracting object and test names
- raise a clear error when the value does not contain both parts
- add a regression test for short invalid values

## How to verify

```bash
pnpm exec mocha test/commands/java/test_test.js --timeout 1200000