### PR TITLE
fix(#1111): skip empty comment placeholders

### DIFF
--- a/src/commands/generate_comments.js
+++ b/src/commands/generate_comments.js
@@ -101,6 +101,9 @@ function getTextFocusedOnSpecificPlaceholder(
  * @return {Promise<Array.<String>>} of ordered LLM outputs (one for each placeholder in the input)
  */
 function generateDocumentation(inputCode, commentPlaceholder, chain) {
+  if (commentPlaceholder.length === 0) {
+    return Promise.resolve([]);
+  }
   const commentPlaceholderRegex = new RegExp(escapeRegExp(commentPlaceholder), 'g');
   const allLocationsOfPlaceholderInInputCode = Array.from(inputCode.matchAll(commentPlaceholderRegex));
   return Promise.all(allLocationsOfPlaceholderInInputCode.map((location) => {

--- a/test/commands/test_generate_comments.js
+++ b/test/commands/test_generate_comments.js
@@ -77,6 +77,19 @@ describe('generate_comments', () => {
     verifyGeneratedOutput(stdout, home, outputFilePath, []);
     done();
   });
+  it('produces empty output when --comment_placeholder is empty', (done) => {
+    const home = makeHome();
+    const outputFilePath = path.resolve(home, 'out.json');
+    const stdout = runSync([
+      'generate_comments',
+      '--provider=placeholder',
+      '--comment_placeholder=',
+      `--prompt_template=${makePromptFile(home, '')}`,
+      `--source=${makeInputFile(home, '# docs\n[] > app')}`,
+      `--output=${outputFilePath}`]);
+    verifyGeneratedOutput(stdout, home, outputFilePath, []);
+    done();
+  });
   it('does not leak the placeholders counter into the global scope', () => {
     assert.strictEqual(globalThis.placeholders, undefined, 'placeholders leaked onto the global object');
   });


### PR DESCRIPTION
 Closes #1111.

## What was happening

When `--comment_placeholder` was empty, `generate_comments` built a regex from the empty string and matched every position in the source. That caused the provider to be invoked for every position instead of producing an empty result.

## What changed

- return an empty documentation list immediately when `--comment_placeholder` is empty
- add a regression test for the empty placeholder case