### PR TITLE
fix(#1101): reuse demand.gte in lint

### DIFF
--- a/src/commands/lint.js
+++ b/src/commands/lint.js
@@ -7,7 +7,7 @@ const rel = require('relative');
 const path = require('path');
 const {mvnw, flags} = require('../mvnw');
 const {elapsed} = require('../elapsed');
-const semver = require('semver');
+const {gte} = require('../demand');
 
 /**
  * Command to lint .XMIR files.
@@ -61,7 +61,7 @@ module.exports.goals = goals;
 module.exports.extras = extras;
 
 function goals(opts) {
-  if (opts.parser.endsWith('-SNAPSHOT') || semver.gte(opts.parser, '0.45.0')) {
+  if (gte('EO parser', opts.parser, '0.45.0', false)) {
     return ['eo:lint'];
   }
   return ['eo:verify'];

--- a/src/demand.js
+++ b/src/demand.js
@@ -12,15 +12,19 @@ const semver = require('semver');
  * @param {String} current - Current version
  * @param {String} min - Minimal expected version
  */
-module.exports.gte = function(subject, current, min) {
+module.exports.gte = function(subject, current, min, enforce = true) {
   if (current.endsWith('-SNAPSHOT')) {
-    return;
+    return true;
   }
   if (semver.lt(current, min)) {
-    console.error(
-      '%s is required to have version %s or higher, while you use %s',
-      subject, min, current
-    );
-    process.exit(1);
+    if (enforce) {
+      console.error(
+        '%s is required to have version %s or higher, while you use %s',
+        subject, min, current
+      );
+      process.exit(1);
+    }
+    return false;
   }
+  return true;
 };

--- a/test/commands/test_lint.js
+++ b/test/commands/test_lint.js
@@ -15,6 +15,14 @@ describe('lint', () => {
     assert.deepEqual(lint.extras({easy: true}), ['-Deo.failOnWarning=false']);
     done();
   });
+  it('selects eo:verify before parser 0.45.0', () => {
+    assert.deepEqual(lint.goals({parser: '0.44.0'}), ['eo:verify']);
+  });
+  it('selects eo:lint for parser 0.45.0 and newer', () => {
+    assert.deepEqual(lint.goals({parser: '0.45.0'}), ['eo:lint']);
+    assert.deepEqual(lint.goals({parser: '0.45.1'}), ['eo:lint']);
+    assert.deepEqual(lint.goals({parser: '0.45.0-SNAPSHOT'}), ['eo:lint']);
+  });
   before(weAreOnline);
   it('lints a simple .EO program', (done) => {
     const home = path.resolve('temp/test-lint/simple');


### PR DESCRIPTION
Closes #1101.

## What changed

`src/demand.js` already had a version comparison helper, but `lint.js` still used `semver.gte()` directly. This PR wires `lint.js` to the shared helper instead.

## Details

- make `demand.gte()` return a boolean
- preserve the existing strict behavior by default
- allow non-fatal comparisons for callers that only need branching logic
- use `demand.gte()` in `lint.goals()`
- add regression coverage for parser versions before and after `0.45.0`, including `-SNAPSHOT`