### PR TITLE
fix(#1084): preserve spaced target paths in eo2jsw

### DIFF
--- a/src/eo2jsw.js
+++ b/src/eo2jsw.js
@@ -4,7 +4,7 @@
  */
 
 const path = require('path');
-const {execSync} = require('child_process'),
+const {execFileSync} = require('child_process'),
 
   /**
    * Convert eoc arguments to appropriate eo2js flags
@@ -33,8 +33,9 @@ const {execSync} = require('child_process'),
     const lib = path.resolve(__dirname, '../node_modules/eo2js/src'),
       bin = path.resolve(lib, 'eo2js.js');
     return new Promise((resolve, reject) => {
-      execSync(
-        `node ${bin} ${command} ${flags(args, lib).filter((flag) => flag !== '').join(' ')}`,
+      execFileSync(
+        'node',
+        [bin, command].concat(flags(args, lib).filter((flag) => flag !== '')),
         {
           timeout: 1200000,
           windowsHide: true,

--- a/test/test_eo2jsw.js
+++ b/test/test_eo2jsw.js
@@ -1,0 +1,40 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+const path = require('path');
+const childProcess = require('child_process');
+
+describe('eo2jsw', () => {
+  it('passes a target path with spaces as a single argument', async () => {
+    const original = childProcess.execFileSync;
+    const calls = [];
+    childProcess.execFileSync = (file, args, options) => {
+      calls.push({file, args, options});
+    };
+    delete require.cache[require.resolve('../src/eo2jsw')];
+    const eo2jsw = require('../src/eo2jsw');
+    try {
+      await eo2jsw('transpile', {
+        target: path.join('temp', 'My Project', 'target'),
+        project: 'project',
+        alone: true,
+      });
+    } finally {
+      childProcess.execFileSync = original;
+      delete require.cache[require.resolve('../src/eo2jsw')];
+    }
+    assert.strictEqual(calls.length, 1, 'expected one eo2js invocation');
+    assert.strictEqual(calls[0].file, 'node');
+    assert.ok(
+      calls[0].args.includes(path.join('temp', 'My Project', 'target')),
+      `expected target path to stay intact, got: ${JSON.stringify(calls[0].args)}`
+    );
+    assert.ok(
+      !calls[0].args.includes('temp/My') && !calls[0].args.includes('temp\\My'),
+      `expected no shell-split fragments, got: ${JSON.stringify(calls[0].args)}`
+    );
+  });
+});


### PR DESCRIPTION
Closes #1084.

## What was happening

`src/eo2jsw.js` built a single shell command string and passed it to `execSync()`. When `--target` contained spaces, the shell split the path and passed a corrupted value to `eo2js`.

## What changed

- switch `eo2jsw` from shell-string execution to `execFileSync()`
- pass `node`, the script path, and flags as separate arguments
- add a regression test that verifies a target path with spaces is preserved as a single argument
