### PR TITLE
fix(#1123): preserve dash-prefixed arguments in js dataize

### DIFF
--- a/src/commands/js/dataize.js
+++ b/src/commands/js/dataize.js
@@ -14,7 +14,7 @@ const eo2jsw = require('../../eo2jsw');
  */
 module.exports = function(obj, args, opts) {
   return eo2jsw(
-    ['dataize', obj, ...args.filter((arg) => !arg.startsWith('-'))].join(' '),
+    ['dataize', obj, ...args].join(' ')
     {...opts, alone: true, project: 'project'}
   );
 };


### PR DESCRIPTION
Closes #1123.

## Problem

The JavaScript `dataize` command currently strips any argument that starts with `-` before passing arguments forward.

That is incorrect because a dash-prefixed value is not always a CLI option. It may be a legitimate object argument. As a result, some valid inputs are silently lost and the JS backend behaves differently from the Java backend.

## Why this fix works

The correct behavior is to preserve object arguments exactly as the user passed them.

With this change, dash-prefixed values are no longer discarded, so:

- valid arguments continue through the full execution path
- the JavaScript backend stops corrupting the input
- behavior becomes consistent with the Java backend

This works because the bug is not in parsing later stages. The problem is the premature filtering step itself. Once that filtering is removed, the original input reaches the command intact.