### PR TITLE
Closes #1127. Check pinned version for remaining commands

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -175,6 +175,7 @@ program.command('audit')
 program.command('foreign')
   .description('Inspect and print the list of foreign objects')
   .action((str, opts) => {
+    pin(program.opts());
     coms().foreign(program.opts());
   });
 
@@ -360,6 +361,7 @@ program.command('generate_comments')
     'Path to prompt template file, ' +
     'where `{code}` placeholder will be replaced with the code given by the user')
   .action(async (str, opts) => {
+    pin(program.opts());
     await coms().generate_comments({...program.opts(), ...str});
   });
 

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -265,6 +265,32 @@ describe('eoc', () => {
 });
 
 describe('eoc', () => {
+  it('fails foreign due to version mismatch if different --pin provided', (done) => {
+    assert.throws(
+      () => {
+        runSync(['--pin=29.9.4', 'foreign']);
+      },
+      /Version mismatch: you are running eoc [0-9]+\.[0-9]+\.[0-9]+, but --pin option requires 29.9.4/
+    );
+    done();
+  });
+  it('fails generate_comments due to version mismatch if different --pin provided', (done) => {
+    assert.throws(
+      () => {
+        runSync([
+          '--pin=29.9.4',
+          'generate_comments',
+          '--provider=placeholder',
+          '--source=absent.eo',
+          '--prompt_template=absent.txt'
+        ]);
+      },
+      /Version mismatch: you are running eoc [0-9]+\.[0-9]+\.[0-9]+, but --pin option requires 29.9.4/
+    );
+    done();
+  });
+});
+describe('eoc', () => {
   before(weAreOnline);
   it('fails link due to version mismatch if different --pin provided', (done) => {
     assert.throws(


### PR DESCRIPTION
Closes #1127.

The `foreign` and `generate_comments` commands previously ignored the global
`--pin` option.

Both commands continued execution even when the requested pinned version did
not match the current `eoc` version.

This change performs the pin check before either command starts its main
logic.

Regression tests verify that both commands fail with a version mismatch when
an incompatible `--pin` value is provided.

Tests:
- `npx eslint src/eoc.js test/test_eoc.js`
- `npx mocha test/test_eoc.js --grep "version mismatch" --timeout 1200000` — 6 passing
- `npm test` — 178 passing, 10 pending
- `npx grunt` — 178 passing, 10 pending