### PR TITLE
fix(#1120): use maximum heap limit for Java runner

### DIFF
--- a/src/commands/java/dataize.js
+++ b/src/commands/java/dataize.js
@@ -13,20 +13,21 @@ const {verifyJavac} = require('../../jdk');
  * @param {Array} args - Arguments
  * @param {Object} opts - All options
  * @param {Function} [exec] - Optional command runner for the JDK check
+ * @param {Function} [runner] - Optional Java process runner
  */
-module.exports = function(obj, args, opts, exec) {
+module.exports = function(obj, args, opts, exec, runner = spawn) {
   verifyJavac(exec);
   const params = [
     '-Dfile.encoding=UTF-8',
     `-Xss${opts.stack}`,
-    `-Xms${opts.heap}`,
+    `-Xmx${opts.heap}`,
     '-jar', path.resolve(opts.target, 'eoc.jar'),
     opts.verbose ? '--verbose' : '',
     obj,
     ...args,
   ].filter((i) => i);
   console.debug(`+ java ${params.join(' ')}`);
-  spawn('java', params, {stdio: 'inherit'}).on('close', (code) => {
+  runner('java', params, {stdio: 'inherit'}).on('close', (code) => {
     if (code !== 0) {
       console.error(`JVM failed with exit code ${code}`);
       process.exit(1);

--- a/test/commands/test_dataize.js
+++ b/test/commands/test_dataize.js
@@ -86,6 +86,27 @@ describe('dataize', () => {
 });
 
 describe('dataize/java', () => {
+  it('sets the maximum Java heap size', () => {
+    let params;
+    dataize(
+      'main.foo',
+      [],
+      {target: '.', stack: '64M', heap: '256M'},
+      () => true,
+      (command, args) => {
+        params = args;
+        return {on: () => true};
+      }
+    );
+    assert(
+      params.includes('-Xmx256M'),
+      'dataize does not set the maximum Java heap size'
+    );
+    assert(
+      !params.some((param) => param.startsWith('-Xms')),
+      'dataize still sets the initial Java heap size'
+    );
+  });
   it('fails fast with a clear message when javac is not on the PATH', () => {
     const missing = () => {
       const cause = new Error('spawnSync javac ENOENT');


### PR DESCRIPTION
Closes #1120

## What changed

The Java `dataize` runner now maps `--heap` to `-Xmx` instead of `-Xms`,
so the option controls the JVM maximum heap as documented.

The Java process runner is injectable for unit testing. A regression test
captures the generated arguments and verifies that `-Xmx256M` is present
and no `-Xms` argument remains.

## Verification

- `npx mocha test/commands/test_dataize.js --grep "dataize/java"`
  - 4 tests passing
- `npx eslint .`
  - passed
- `npx grunt --file=test/commands/test_dataize.js`
  - the 4 unit tests passed
  - the 2 CLI integration cases could not run locally on Windows because
    their pipeline did not create `target/eoc.jar`

@yegor256
