### PR TITLE
Closes #1144. Handle root-level XMIR without a package

### DIFF
--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -139,17 +139,23 @@ module.exports = function(opts) {
         const html_app = path.join(output, path.dirname(relative),`${name}.html`);
         fs.mkdirSync(path.dirname(html_app), {recursive: true});
         fs.writeFileSync(html_app, wrapHtml(name, xmir_html, css));
-        const packages = path.dirname(relative).split(path.sep).join('.');
-        const html_package = path.join(output, `package_${packages}.html`);
-        if (!packages_info.has(packages)) {
-          packages_info.set(packages, {
-            xmir_htmls : [],
-            names: [],
-            path: html_package
-          });
+        const package_dir = path.dirname(relative);
+        if (package_dir !== '.') {
+          const package_name = package_dir.split(path.sep).join('.');
+          const html_package = path.join(
+            output,
+            `package_${package_name}.html`
+          );
+          if (!packages_info.has(package_name)) {
+            packages_info.set(package_name, {
+              xmir_htmls : [],
+              names: [],
+              path: html_package
+            });
+          }
+          packages_info.get(package_name).xmir_htmls.push(xmir_html);
+          packages_info.get(package_name).names.push(name);
         }
-        packages_info.get(packages).xmir_htmls.push(xmir_html);
-        packages_info.get(packages).names.push(name);
         all_xmir_htmls.push(xmir_html);
       }
       for (const [package_name, info] of packages_info) {

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -48,6 +48,50 @@ describe('docs', () => {
     done();
   });
   /**
+   * Tests that a root-level XMIR is not assigned the "." filesystem
+   * marker as its package name.
+   * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
+   */
+  it('does not expose "." as a package for root-level XMIR', (done) => {
+    fs.writeFileSync(
+      path.join(parsed, 'app.xmir'),
+      '<program name="app" />'
+    );
+    runSync([
+      'docs',
+      '--verbose',
+      '-s', path.resolve(home, 'src'),
+      '-t', home,
+    ]);
+    const app_html = path.join(docs, 'app.html');
+    assert(
+      fs.existsSync(app_html),
+      `Expected root object page ${app_html} but it was not created`
+    );
+    const invalid_package = path.join(docs, 'package_..html');
+    assert(
+      !fs.existsSync(invalid_package),
+      `Unexpected package page ${invalid_package}`
+    );
+    const summary = fs.readFileSync(
+      path.join(docs, 'summary.xml'),
+      'utf-8'
+    );
+    assert(
+      summary.includes('packages="0"'),
+      'Expected no package for a root-level XMIR'
+    );
+    assert(
+      summary.includes('objects="1"'),
+      'Expected the root-level object to remain in the object count'
+    );
+    assert(
+      !summary.includes('<package name=".">'),
+      'The filesystem marker "." must not be exposed as a package name'
+    );
+    done();
+  });
+  /**
    * Tests that 'docs' does not crash for a package whose name is an
    * inherited object property, such as 'constructor'.
    * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion


### PR DESCRIPTION
Closes #1144.

The `docs` command previously treated the filesystem marker `.` as an actual
package name when an XMIR file was located directly in the `1-parse`
directory.

This produced a `package_..html` file and exposed `.` as the package name in
`summary.xml`.

This change handles root-level XMIR files separately. Their object pages are
still generated and included in the total object count, but no artificial
package is created for them.

A regression test verifies that:

- the root-level object page is generated;
- `package_..html` is not generated;
- `summary.xml` contains no package named `.`;
- the root-level object remains included in the object count.

Tests:
- `npx eslint src/commands/docs.js test/commands/test_docs.js`
- `npx mocha test/commands/test_docs.js --grep "root-level XMIR" --timeout 1200000` — 1 passing
- `npx mocha test/commands/test_docs.js --timeout 1200000` — 14 passing
- `npm test` — 186 passing, 10 pending
- `npx grunt` — 186 passing, 10 pending