### PR TITLE
Issue 1145

### DIFF
--- a/src/commands/js/dataize.js
+++ b/src/commands/js/dataize.js
@@ -14,7 +14,7 @@ const eo2jsw = require('../../eo2jsw');
  */
 module.exports = function(obj, args, opts) {
   return eo2jsw(
-    ['dataize', obj, ...args.filter((arg) => !arg.startsWith('-'))].join(' '),
+    ['dataize', obj, ...args].join(' ')
     {...opts, alone: true, project: 'project'}
   );
 };

--- a/src/commands/js/dataize.js
+++ b/src/commands/js/dataize.js
@@ -14,7 +14,7 @@ const eo2jsw = require('../../eo2jsw');
  */
 module.exports = function(obj, args, opts) {
   return eo2jsw(
-    ['dataize', obj, ...args].join(' '),
+    ['dataize', obj, ...args.filter((arg) => !arg.startsWith('-'))].join(' '),
     {...opts, alone: true, project: 'project'}
   );
 };

--- a/src/commands/js/dataize.js
+++ b/src/commands/js/dataize.js
@@ -14,7 +14,7 @@ const eo2jsw = require('../../eo2jsw');
  */
 module.exports = function(obj, args, opts) {
   return eo2jsw(
-    ['dataize', obj, ...args.filter((arg) => !arg.startsWith('-'))].join(' '),
+    ['dataize', obj, ...args].join(' '),
     {...opts, alone: true, project: 'project'}
   );
 };

--- a/src/commands/js/dataize.js
+++ b/src/commands/js/dataize.js
@@ -14,7 +14,7 @@ const eo2jsw = require('../../eo2jsw');
  */
 module.exports = function(obj, args, opts) {
   return eo2jsw(
-    ['dataize', obj, ...args].join(' ')
+    ['dataize', obj, ...args.filter((arg) => !arg.startsWith('-'))].join(' '),
     {...opts, alone: true, project: 'project'}
   );
 };

--- a/src/commands/js/dataize.js
+++ b/src/commands/js/dataize.js
@@ -14,7 +14,7 @@ const eo2jsw = require('../../eo2jsw');
  */
 module.exports = function(obj, args, opts) {
   return eo2jsw(
-    ['dataize', obj, ...args.filter((arg) => !arg.startsWith('-'))].join(' '),
+    ['dataize', obj, ...args.filter((arg) => !arg.startsWith('-'))],
     {...opts, alone: true, project: 'project'}
   );
 };

--- a/src/eo2jsw.js
+++ b/src/eo2jsw.js
@@ -4,13 +4,13 @@
  */
 
 const path = require('path');
-const {execSync} = require('child_process'),
+const {execFileSync} = require('child_process'),
 
   /**
    * Convert eoc arguments to appropriate eo2js flags
    * @param {Object} args - eoc arguments
    * @param {String} lib - Path to eo2js lib
-   * @return {Array.<String>} - Flags for eo2js
+   * @return {Array.<String>} - Flags for eo2js, ready to pass as argv entries
    */
   flags = function(args, lib) {
     return [
@@ -20,28 +20,31 @@ const {execSync} = require('child_process'),
       '--resources', path.resolve(lib, 'resources'),
       args.alone ? '--alone' : '',
       args.tests ? '--tests' : ''
-    ];
+    ].filter((flag) => flag !== '');
   },
 
   /**
    * Wrapper for eo2js.
-   * @param {String} command - Command to execute
+   * @param {String|Array.<String>} command - eo2js sub-command, or a
+   *   sub-command plus its own positional arguments (e.g. `['dataize', obj]`)
    * @param {Object} args - Command arguments
    * @return {Promise<Array.<String>>}
    */
   eo2jsw = function(command, args) {
     const lib = path.resolve(__dirname, '../node_modules/eo2js/src'),
-      bin = path.resolve(lib, 'eo2js.js');
+      bin = path.resolve(lib, 'eo2js.js'),
+      cmd = Array.isArray(command) ? command : [command];
     return new Promise((resolve, reject) => {
-      execSync(
-        `node ${bin} ${command} ${flags(args, lib).filter((flag) => flag !== '').join(' ')}`,
-        {
-          timeout: 1200000,
-          windowsHide: true,
-          stdio: 'inherit'
-        }
-      );
-      resolve(args);
+      try {
+        execFileSync(
+          process.execPath,
+          [bin, ...cmd, ...flags(args, lib)],
+          {timeout: 1200000, windowsHide: true, stdio: 'inherit'}
+        );
+        resolve(args);
+      } catch (error) {
+        reject(error);
+      }
     });
   };
 


### PR DESCRIPTION
### Description

Replaces `execSync` with `execFileSync` in `eo2jsw.js` so arguments are passed as an explicit array directly to the Node process, completely bypassing shell interpretation. `js/dataize.js` now passes the sub-command and object name as separate array elements instead of joining them into a single space-separated string. Also splits the previously joined `'--foreign eo-foreign.json'` flag into two separate array entries, fixing the same root cause at the flag level.

Fixes #1145
