### PR TITLE
fix(#1146): correct the hasOwnProperty check in tinted-console.enable()

### DIFF
--- a/src/tinted-console.js
+++ b/src/tinted-console.js
@@ -39,16 +39,13 @@ for (const level in levels) {
 }
 
 /**
- * Enable this particular logging level.
+ * Enable this particular logging level (and only this one).
  * @param {String} level - The level to enable
+ * @throws {Error} If the level name is not one of the known levels
  */
 module.exports.enable = function enable(level) {
-  for (const key in levels) {
-    if (levels.hasOwnProperty(level)) {
-      levels[key] = true;
-      if (key === level) {
-        break;
-      }
-    }
+   if (!levels.hasOwnProperty(level)) {
+    throw new Error(`Unknown log level: "${level}"`);
   }
+  levels[level] = true;
 };


### PR DESCRIPTION
### Description

Removes the broken `for...in` loop entirely. The function now checks directly whether the requested level exists as a property of the `levels` object. If it doesn't, an error is thrown immediately with the unknown level name in the message. If it does, only that single key is set to `true`. The JSDoc is updated to document the new `@throws` behaviour and to clarify that only the requested level is enabled.

### What changed

**`src/tinted-console.js`** — The `enable` function body went from a multi-iteration loop with a mis-scoped condition to a straightforward guard-and-set: first check `!levels.hasOwnProperty(level)` and throw if the level is unknown, then `levels[level] = true` directly. This eliminates the loop, the incorrect variable reference, and the silent failure on typos all at once.
Fixes #1146