### PR TITLE
#1121: declare saxon-js as direct dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "fast-xml-parser": "^5.10.1",
         "marked": "^4.3.0",
         "relative": "^3.0.2",
+        "saxon-js": "^2.7.0",
         "semver": "^7.7.2",
         "sync-request": "^6.1.0",
         "xmlhttprequest": "^1.8.0"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "fast-xml-parser": "^5.10.1",
     "marked": "^4.3.0",
     "relative": "^3.0.2",
+    "saxon-js": "^2.7.0",
     "semver": "^7.7.2",
     "sync-request": "^6.1.0",
     "xmlhttprequest": "^1.8.0"

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -370,4 +370,13 @@ describe('docs', () => {
     );
     done();
   });
+  /**
+   * Tests that 'saxon-js', required directly by this module, is declared
+   * as its own dependency instead of relying on it being pulled in
+   * transitively through 'eo2js'.
+   */
+  it('declares saxon-js as a direct dependency', () => {
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf-8'));
+    assert.ok(pkg.dependencies['saxon-js'], 'saxon-js must be listed in package.json dependencies');
+  });
 });

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -371,12 +371,22 @@ describe('docs', () => {
     done();
   });
   /**
-   * Tests that 'saxon-js', required directly by this module, is declared
-   * as its own dependency instead of relying on it being pulled in
-   * transitively through 'eo2js'.
+   * Tests that every package 'docs.js' requires is declared by 'eoc' itself
+   * and resolves, instead of being reached transitively through 'eo2js'.
    */
-  it('declares saxon-js as a direct dependency', () => {
+  it('declares every package it requires', () => {
+    const source = path.join(__dirname, '..', '..', 'src', 'commands', 'docs.js');
     const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', '..', 'package.json'), 'utf-8'));
-    assert.ok(pkg.dependencies['saxon-js'], 'saxon-js must be listed in package.json dependencies');
+    const required = [...fs.readFileSync(source, 'utf-8').matchAll(/require\('(?<name>[^.'][^']*)'\)/g)]
+      .map((match) => match.groups.name)
+      .filter((name) => !require('module').builtinModules.includes(name));
+    assert.notStrictEqual(required.length, 0, 'no external requires were found in docs.js');
+    required.forEach((name) => {
+      assert.ok(pkg.dependencies[name], `${name} is required by docs.js but not in package.json dependencies`);
+      assert.doesNotThrow(
+        () => require.resolve(name, {paths: [path.dirname(source)]}),
+        `${name} is declared but does not resolve`
+      );
+    });
   });
 });


### PR DESCRIPTION
Closes #1121

`saxon-js` is required directly by `src/commands/docs.js` but was not declared in `package.json`'s own `dependencies`, only pulled in transitively through `eo2js`. Added it as a direct dependency, matching how `marked` (also used only by `docs.js`) is already declared.

Added a test asserting `saxon-js` is listed in `package.json` dependencies.
