### PR TITLE
#500: start the inspection server and ask it where the session begins

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ You can also do many other things with `eoc` commands
 * `compile` Compile target language sources into binaries
 * `link` Link together all binaries into a single executable binary
 * `dataize` Run the single executable binary and dataize an object
+* `inspect` Traverse the tree of objects of a compiled program
 * `test` Run all visible unit tests
 * `docs` Generate documentation from XMIR files
 * `generate_comments` Generate documentation with LLM

--- a/inspect/pom.xml
+++ b/inspect/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+* SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+* SPDX-License-Identifier: MIT
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.eolang</groupId>
+  <artifactId>eoc-inspect</artifactId>
+  <version>0.0.0</version>
+  <packaging>jar</packaging>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <eo.version>undefined</eo.version>
+    <eo.targetDir>${project.basedir}/target</eo.targetDir>
+    <takes.version>1.24.6</takes.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>org.takes</groupId>
+      <artifactId>takes</artifactId>
+      <version>${takes.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.eolang</groupId>
+      <artifactId>eo-runtime</artifactId>
+      <version>${eo.version}</version>
+      <scope>provided</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <finalName>inspect</finalName>
+    <directory>${eo.targetDir}/inspect</directory>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.8.1</version>
+        <configuration>
+          <release>11</release>
+        </configuration>
+      </plugin>
+      <plugin>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.6.2</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <createDependencyReducedPom>false</createDependencyReducedPom>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.eolang.eoc.Inspect</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/inspect/src/main/java/org/eolang/eoc/Inspect.java
+++ b/inspect/src/main/java/org/eolang/eoc/Inspect.java
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang.eoc;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.eolang.Phi;
+import org.takes.Take;
+import org.takes.facets.fork.FkRegex;
+import org.takes.facets.fork.TkFork;
+import org.takes.http.Exit;
+import org.takes.http.FtBasic;
+import org.takes.rs.RsText;
+import org.takes.rs.RsWithType;
+
+/**
+ * The server behind the {@code eoc inspect} command.
+ *
+ * <p>It is started by the JavaScript side as a background process, with
+ * the linked program on the classpath, and it answers HTTP requests about
+ * the tree of objects that lives in its own memory. Nothing is read from
+ * the classpath or from XMIR: the objects are asked directly.</p>
+ *
+ * @todo #500:60min Load the whole tree of objects at startup.
+ *  Right now the only object this server can reach is the root, and it
+ *  reaches it lazily through {@link Phi}. A package object learns that a
+ *  child exists only when that child is taken by name, so listing
+ *  everything under the root is impossible until every object is loaded
+ *  into memory once, at startup, the way the session in this issue shows
+ *  with its "Loaded 56 objects" line. Load them here and keep them, so
+ *  that the verbs below walk a tree that is already there.
+ * @since 0.0.0
+ */
+public final class Inspect {
+
+    /**
+     * Command line arguments the server was started with.
+     */
+    private final List<String> flags;
+
+    /**
+     * Ctor.
+     * @param args Command line arguments
+     */
+    public Inspect(final String... args) {
+        this.flags = Arrays.asList(args);
+    }
+
+    /**
+     * Entry point.
+     * @param args Command line arguments
+     * @throws IOException If fails
+     */
+    public static void main(final String... args) throws IOException {
+        new Inspect(args).start();
+    }
+
+    /**
+     * Start the server and serve until the process is killed.
+     *
+     * @todo #500:90min Answer the verbs that only read the tree.
+     *  The session in this issue moves around before it changes anything:
+     *  ls prints the attributes of the object we are at, go (or .foo)
+     *  steps into one of them, and .. steps back out. All three need the
+     *  server to remember where the session currently is, so add that
+     *  position here first and let these three verbs move it.
+     * @todo #500:90min Answer the verbs that change the current object.
+     *  Here add (or +foo) puts a new void attribute on the object we are
+     *  at, rm (or -foo) takes one away, form attaches an empty formation,
+     *  put attaches data to the delta asset, and to attaches an object
+     *  named elsewhere. All five write into the object, which is what the
+     *  base class of objectionary/eo#6273 is meant to allow.
+     * @todo #500:60min Answer the verbs that copy and dispatch.
+     *  Here cp makes a copy of the object we are at and attaches it under
+     *  a name the caller chooses, and dd dispatches one attribute and
+     *  attaches the result the same way. Both need somewhere to keep
+     *  those names, since a name like the one in the session is invented
+     *  by the user and belongs to no object of the program.
+     * @todo #500:30min Answer the dataize verb.
+     *  Here dataize (or run) dataizes the object the session is at and
+     *  answers with its bytes, which the JavaScript side prints the way
+     *  the session in the issue shows. A program that fails to dataize is
+     *  the reason this tool exists, so answer with the failure instead of
+     *  letting the server die on it.
+     * @throws IOException If fails
+     */
+    public void start() throws IOException {
+        new FtBasic(
+            new TkFork(
+                new FkRegex(
+                    "/",
+                    (Take) req -> new RsWithType.Json(
+                        new RsText(String.format("{\"forma\":\"%s\"}", Phi.Φ.forma()))
+                    )
+                )
+            ),
+            this.port()
+        ).start(Exit.NEVER);
+    }
+
+    /**
+     * The port to listen on, taken from the {@code --port} option.
+     * @return The port number
+     */
+    private int port() {
+        final int idx = this.flags.indexOf("--port");
+        if (idx < 0 || idx + 1 == this.flags.size()) {
+            throw new IllegalArgumentException(
+                "The --port option is mandatory, as in \"--port 8080\""
+            );
+        }
+        return Integer.parseInt(this.flags.get(idx + 1));
+    }
+}

--- a/src/commands/java/inspect.js
+++ b/src/commands/java/inspect.js
@@ -1,0 +1,97 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const fs = require('fs');
+const path = require('path');
+const {spawn} = require('node:child_process');
+const {mvnw, flags} = require('../../mvnw');
+const {verifyJavac} = require('../../jdk');
+
+/**
+ * The jar with the inspection server, built on demand.
+ * @param {Object} opts - All options
+ * @return {Promise<String>} Path to the jar
+ */
+async function jar(opts) {
+  const built = path.resolve(opts.target, 'inspect', 'inspect.jar');
+  if (!fs.existsSync(built)) {
+    await mvnw(
+      ['package', '-f', path.resolve(__dirname, '../../../inspect/pom.xml')].concat(flags(opts)),
+      opts.target,
+      opts.batch
+    );
+  }
+  return built;
+}
+
+/**
+ * Ask the server where the session currently is, waiting for it to open the port.
+ * The address is IPv4 on purpose, since the server listens on IPv4 while
+ * "localhost" resolves to ::1 first on some machines and is refused there.
+ * @param {Number} port - TCP port the server listens on
+ * @param {Number} deadline - Moment in time after which we give up, in millis
+ * @return {Promise<Object>} The answer, parsed from JSON
+ */
+async function ask(port, deadline) {
+  let answer;
+  try {
+    answer = await (await fetch(`http://127.0.0.1:${port}/`)).json();
+  } catch (error) {
+    if (Date.now() > deadline) {
+      throw new Error(
+        `The inspection server has not opened port ${port} in a minute`,
+        {cause: error}
+      );
+    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    answer = await ask(port, deadline);
+  }
+  return answer;
+}
+
+/**
+ * Traverse the tree of objects of a compiled program.
+ *
+ * The server runs in a separate JVM, with the linked program on its
+ * classpath, and every question about the tree is an HTTP request to it.
+ *
+ * @todo #500:60min Turn this single question into an interactive session.
+ *  The issue asks for a prompt that stays open, reads a verb from the
+ *  terminal, sends it to the server and prints the answer, until the user
+ *  leaves. Right now we ask one question and shut the server down. Add
+ *  the loop, and keep the printing here, since the server is the only one
+ *  that knows the objects and this side is the only one that knows the
+ *  terminal.
+ * @todo #500:30min Do not leave the JVM behind when this process dies.
+ *  The server is killed in the "finally" below, which covers a failure of
+ *  our own code, but not a user pressing Ctrl-C and not a crash of the
+ *  Node process itself. In both cases the JVM keeps the port open and the
+ *  next run of the command fails to bind it. Kill the child on the
+ *  signals too, and report a port that is already taken by naming it.
+ * @param {Object} opts - All options
+ * @param {Function} [exec] - Optional command runner for the JDK check
+ * @param {Function} [runner] - Optional Java process runner
+ * @return {Promise} of the inspection session
+ */
+module.exports = async function(opts, exec, runner = spawn) {
+  verifyJavac(exec);
+  const port = Number(opts.port);
+  const params = [
+    '-cp',
+    [path.resolve(opts.target, 'eoc.jar'), await jar(opts)].join(path.delimiter),
+    'org.eolang.eoc.Inspect',
+    '--port',
+    String(port),
+  ];
+  console.debug(`+ java ${params.join(' ')}`);
+  const server = runner('java', params, {stdio: 'inherit'});
+  try {
+    const answer = await ask(port, Date.now() + 60000);
+    console.info('Ready to traverse the Universe');
+    console.info(`@ ${answer.forma}`);
+  } finally {
+    server.kill();
+  }
+};

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -48,6 +48,7 @@ const commands = {
       compile: require('./commands/java/compile'),
       dataize: require('./commands/java/dataize'),
       test: require('./commands/java/test'),
+      inspect: require('./commands/java/inspect'),
     }
   },
   [language.js]: {
@@ -316,6 +317,22 @@ program.command('dataize')
         program.args[1], program.args.slice(2), {...program.opts(), ...str}
       );
     }
+  });
+
+program.command('inspect')
+  .description('Traverse the tree of objects of a compiled program')
+  .option('--port <number>', 'TCP port for the inspection server', '8080')
+  .action(async (str, opts) => {
+    pin(program.opts());
+    clear(str);
+    const inspect = coms().inspect;
+    if (inspect === undefined) {
+      throw new Error(`The "inspect" command only works for ${language.java}`);
+    }
+    if (program.opts().alone === undefined) {
+      await pipe()(coms(), ['register', 'assemble', 'lint', 'resolve', 'transpile', 'compile', 'link'], program.opts());
+    }
+    await inspect({...program.opts(), ...str});
   });
 
 program.command('test')

--- a/test/commands/test_inspect.js
+++ b/test/commands/test_inspect.js
@@ -6,13 +6,28 @@
 const assert = require('assert');
 const fs = require('fs');
 const http = require('http');
+const net = require('net');
 const path = require('path');
 const inspect = require('../../src/commands/java/inspect');
 const {runSync, parserVersion, homeTag, weAreOnline} = require('../helpers');
 
+/**
+ * Take a port the operating system is willing to give us right now, so that
+ * two suites on the same machine, or a JVM an earlier run left behind, do not
+ * collide on a number written into the test.
+ * @return {Promise<Number>} A port nobody listens on
+ */
+async function free() {
+  const socket = net.createServer();
+  await new Promise((resolve) => socket.listen(0, '127.0.0.1', resolve));
+  const port = socket.address().port;
+  await new Promise((resolve) => socket.close(resolve));
+  return port;
+}
+
 describe('inspect', () => {
   before(weAreOnline);
-  it('prints the object the session starts at', function(done) {
+  it('prints the object the session starts at', async function() {
     this.timeout(0);
     const home = path.resolve('temp/test-inspect');
     fs.rmSync(home, {recursive: true, force: true});
@@ -23,7 +38,7 @@ describe('inspect', () => {
     );
     const stdout = runSync([
       'inspect',
-      '--port=18081',
+      `--port=${await free()}`,
       '--easy',
       '--blind',
       `--parser=${parserVersion}`,
@@ -31,14 +46,19 @@ describe('inspect', () => {
       '-s', home,
       '-t', path.resolve(home, 'target'),
     ]);
-    assert(stdout.includes('@ Φ'), stdout);
-    done();
+    assert(
+      stdout.includes('@ Φ'),
+      `inspect does not print the object the session starts at: ${stdout}`
+    );
   });
 });
 
 describe('inspect/java', () => {
-  it('asks the server and prints the object it answers with', async () => {
-    const home = path.resolve('temp/test-inspect-unit');
+  const home = path.resolve('temp/test-inspect-unit');
+  let params;
+  let printed;
+  let killed;
+  before(async () => {
     fs.rmSync(home, {recursive: true, force: true});
     fs.mkdirSync(path.resolve(home, 'inspect'), {recursive: true});
     fs.writeFileSync(path.resolve(home, 'inspect', 'inspect.jar'), '');
@@ -47,11 +67,10 @@ describe('inspect/java', () => {
       res.end('{"forma":"Φ"}');
     });
     await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
-    const printed = [];
+    printed = [];
+    killed = false;
     const info = console.info;
     console.info = (line) => printed.push(line);
-    let params;
-    let killed = false;
     try {
       await inspect(
         {target: home, port: server.address().port},
@@ -67,25 +86,35 @@ describe('inspect/java', () => {
       console.info = info;
       server.close();
     }
+  });
+  it('runs the server class', () => {
     assert(
       params.includes('org.eolang.eoc.Inspect'),
       `inspect does not run the server class: ${params}`
     );
+  });
+  it('puts the program on the classpath', () => {
     assert(
       params[1].split(path.delimiter).includes(path.resolve(home, 'eoc.jar')),
       `inspect does not put the program on the classpath: ${params}`
     );
+  });
+  it('puts the server on the classpath', () => {
     assert(
       params[1].split(path.delimiter).includes(path.resolve(home, 'inspect', 'inspect.jar')),
       `inspect does not put the server on the classpath: ${params}`
     );
+  });
+  it('prints the object the server answers with', () => {
     assert(
       printed.includes('@ Φ'),
       `inspect does not print the object the session starts at: ${printed}`
     );
+  });
+  it('kills the server when the session ends', () => {
     assert(killed, 'inspect leaves the server running');
   });
-  it('fails fast with a clear message when javac is not on the PATH', async () => {
+  it('fails fast when javac is not on the PATH', async () => {
     const missing = () => {
       const cause = new Error('spawnSync javac ENOENT');
       cause.code = 'ENOENT';
@@ -93,8 +122,8 @@ describe('inspect/java', () => {
     };
     await assert.rejects(
       () => inspect({target: '.', port: 8080}, missing),
-      /javac/,
-      'inspect does not fail fast with a clear javac message when the JDK is missing'
+      (error) => error.cause.code === 'ENOENT',
+      'inspect does not refuse to start when the JDK is missing'
     );
   });
 });

--- a/test/commands/test_inspect.js
+++ b/test/commands/test_inspect.js
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+const fs = require('fs');
+const http = require('http');
+const path = require('path');
+const inspect = require('../../src/commands/java/inspect');
+const {runSync, parserVersion, homeTag, weAreOnline} = require('../helpers');
+
+describe('inspect', () => {
+  before(weAreOnline);
+  it('prints the object the session starts at', function(done) {
+    this.timeout(0);
+    const home = path.resolve('temp/test-inspect');
+    fs.rmSync(home, {recursive: true, force: true});
+    fs.mkdirSync(home, {recursive: true});
+    fs.writeFileSync(
+      path.resolve(home, 'simple.eo'),
+      ['[] > simple', '  42 > @'].join('\n')
+    );
+    const stdout = runSync([
+      'inspect',
+      '--port=18081',
+      '--easy',
+      '--blind',
+      `--parser=${parserVersion}`,
+      `--home-tag=${homeTag}`,
+      '-s', home,
+      '-t', path.resolve(home, 'target'),
+    ]);
+    assert(stdout.includes('@ Φ'), stdout);
+    done();
+  });
+});
+
+describe('inspect/java', () => {
+  it('asks the server and prints the object it answers with', async () => {
+    const home = path.resolve('temp/test-inspect-unit');
+    fs.rmSync(home, {recursive: true, force: true});
+    fs.mkdirSync(path.resolve(home, 'inspect'), {recursive: true});
+    fs.writeFileSync(path.resolve(home, 'inspect', 'inspect.jar'), '');
+    const server = http.createServer((req, res) => {
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end('{"forma":"Φ"}');
+    });
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const printed = [];
+    const info = console.info;
+    console.info = (line) => printed.push(line);
+    let params;
+    let killed = false;
+    try {
+      await inspect(
+        {target: home, port: server.address().port},
+        () => true,
+        (command, args) => {
+          params = args;
+          return {kill: () => {
+            killed = true;
+          }};
+        }
+      );
+    } finally {
+      console.info = info;
+      server.close();
+    }
+    assert(
+      params.includes('org.eolang.eoc.Inspect'),
+      `inspect does not run the server class: ${params}`
+    );
+    assert(
+      params[1].split(path.delimiter).includes(path.resolve(home, 'eoc.jar')),
+      `inspect does not put the program on the classpath: ${params}`
+    );
+    assert(
+      params[1].split(path.delimiter).includes(path.resolve(home, 'inspect', 'inspect.jar')),
+      `inspect does not put the server on the classpath: ${params}`
+    );
+    assert(
+      printed.includes('@ Φ'),
+      `inspect does not print the object the session starts at: ${printed}`
+    );
+    assert(killed, 'inspect leaves the server running');
+  });
+  it('fails fast with a clear message when javac is not on the PATH', async () => {
+    const missing = () => {
+      const cause = new Error('spawnSync javac ENOENT');
+      cause.code = 'ENOENT';
+      throw cause;
+    };
+    await assert.rejects(
+      () => inspect({target: '.', port: 8080}, missing),
+      /javac/,
+      'inspect does not fail fast with a clear javac message when the JDK is missing'
+    );
+  });
+});


### PR DESCRIPTION
First slice of #500. It starts the server, asks it one question and prints the answer. The verbs come next, each marked with a `@todo` in the code.

- `inspect/` is a small Maven project that builds `inspect.jar` with `org.eolang.eoc.Inspect` inside. It runs a Takes server on the port given by `--port` and answers `GET /` with JSON about the object the session starts at. The root object is taken from memory, nothing is read from the classpath or from XMIR. `eo-runtime` is `provided`, since the program's own jar already carries it.
- `src/commands/java/inspect.js` builds that jar on first use, spawns `java -cp <target>/eoc.jar:<target>/inspect/inspect.jar org.eolang.eoc.Inspect --port N`, waits for the port, asks, prints, and kills the JVM.
- `eoc inspect` is registered in `src/eoc.js`, with `--port` defaulting to 8080.

This follows the design in your comment above: a second jar, the EO jar untouched, a background JVM, Takes, JSON back to the JavaScript side.

Two tests. One compiles a program and checks the command prints the root object. The other runs the JavaScript side against a stub server and checks both jars land on the classpath and the JVM is killed afterwards.

Not closing the issue with this PR. The puzzles say what is left: loading the whole tree at startup, then the verbs in four groups, then the interactive loop and killing the JVM on signals.
