### PR TITLE
Run the CLI through one helper in tests

### DIFF
--- a/test/commands/test_clean.js
+++ b/test/commands/test_clean.js
@@ -7,7 +7,7 @@ const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
-const {runSync} = require('../helpers');
+const {runSync, runOutput} = require('../helpers');
 
 describe('clean', () => {
   const testDir = 'temp/test-clean',
@@ -52,21 +52,16 @@ describe('clean', () => {
     done();
   });
   it('refuses to delete the current working directory', (done) => {
-    const {spawnSync} = require('child_process');
     const home = path.resolve(testDir, 'refuses-cwd');
     fs.rmSync(home, {recursive: true, force: true});
     fs.mkdirSync(home, {recursive: true});
-    const s = spawnSync(
-      'node', [path.resolve('./src/eoc.js'), '--target', '.', 'clean'],
-      {cwd: home}
-    );
-    assert(s.status !== 0, s.stderr.toString());
-    assert(s.stderr.toString().includes('Refusing to delete'), s.stderr.toString());
+    const outcome = runOutput(['--target', '.', 'clean'], {cwd: home});
+    assert(outcome.status !== 0, outcome.stderr);
+    assert(outcome.stderr.includes('Refusing to delete'), outcome.stderr);
     assert(fs.existsSync(home), 'the current directory must not be deleted');
     done();
   });
   it('refuses to delete the current directory through a symbolic link', (done) => {
-    const {spawnSync} = require('child_process');
     const home = path.resolve(testDir, 'refuses-symlink-cwd'),
       real = path.resolve(home, 'real'),
       link = path.resolve(home, 'link'),
@@ -74,20 +69,14 @@ describe('clean', () => {
     fs.rmSync(home, {recursive: true, force: true});
     fs.mkdirSync(real, {recursive: true});
     fs.symlinkSync(home, link, type);
-    const s = spawnSync(
-      'node',
-      [
-        path.resolve('./src/eoc.js'),
-        '--target',
-        path.resolve(link, 'real'),
-        'clean'
-      ],
+    const outcome = runOutput(
+      ['--target', path.resolve(link, 'real'), 'clean'],
       {cwd: real}
     );
-    assert(s.status !== 0, `${s.stdout.toString()}\n${s.stderr.toString()}`);
+    assert(outcome.status !== 0, `${outcome.stdout}\n${outcome.stderr}`);
     assert(
-      s.stderr.toString().includes('Refusing to delete'),
-      s.stderr.toString()
+      outcome.stderr.includes('Refusing to delete'),
+      outcome.stderr
     );
     assert(
       fs.existsSync(real),
@@ -96,29 +85,24 @@ describe('clean', () => {
     done();
   });
   it('refuses to delete an ancestor of the current working directory', (done) => {
-    const {spawnSync} = require('child_process');
     const home = path.resolve(testDir, 'refuses-ancestor'),
       nested = path.resolve(home, 'nested');
     fs.rmSync(home, {recursive: true, force: true});
     fs.mkdirSync(nested, {recursive: true});
-    const s = spawnSync(
-      'node', [path.resolve('./src/eoc.js'), '--target', '..', 'clean'],
-      {cwd: nested}
-    );
-    assert(s.status !== 0, s.stderr.toString());
+    const outcome = runOutput(['--target', '..', 'clean'], {cwd: nested});
+    assert(outcome.status !== 0, outcome.stderr);
     assert(fs.existsSync(home), 'the ancestor directory must not be deleted');
     done();
   });
   it('refuses to delete the home directory', (done) => {
-    const {spawnSync} = require('child_process');
     const fakeHome = path.resolve(testDir, 'fake-home');
     fs.rmSync(fakeHome, {recursive: true, force: true});
     fs.mkdirSync(fakeHome, {recursive: true});
-    const s = spawnSync(
-      'node', [path.resolve('./src/eoc.js'), '--target', fakeHome, 'clean'],
+    const outcome = runOutput(
+      ['--target', fakeHome, 'clean'],
       {env: {...process.env, HOME: fakeHome, USERPROFILE: fakeHome}}
     );
-    assert(s.status !== 0, s.stderr.toString());
+    assert(outcome.status !== 0, outcome.stderr);
     assert(fs.existsSync(fakeHome), 'the home directory must not be deleted');
     done();
   });

--- a/test/commands/test_format.js
+++ b/test/commands/test_format.js
@@ -6,8 +6,7 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const {spawnSync} = require('child_process');
-const {runSync, parserVersion, homeTag, weAreOnline} = require('../helpers');
+const {runSync, runOutput, parserVersion, homeTag, weAreOnline} = require('../helpers');
 
 const messy = '[] > app';
 const tidy = ['[] > app', ''].join('\n');
@@ -47,11 +46,7 @@ function args(home, sources) {
  * @return {Number} Exit code
  */
 function attempt(argv) {
-  return spawnSync(
-    'node',
-    [path.resolve('./src/eoc.js'), '--batch'].concat(argv),
-    {timeout: 1200000, windowsHide: true}
-  ).status;
+  return runOutput(argv).status;
 }
 
 const cases = [

--- a/test/commands/test_transpile.js
+++ b/test/commands/test_transpile.js
@@ -6,7 +6,9 @@
 const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
-const {runSync, assertFilesExist, parserVersion, homeTag, weAreOnline} = require('../helpers');
+const {
+  runSync, runOutput, assertFilesExist, parserVersion, homeTag, weAreOnline
+} = require('../helpers');
 
 describe('transpile', () => {
   before(weAreOnline);
@@ -54,12 +56,9 @@ describe('transpile', () => {
     done();
   });
   it('attempts to transpile a simple .EO program to wrong platform', (done) => {
-    const {spawnSync} = require('child_process'),
-      s = spawnSync(
-        'node', [path.resolve('./src/eoc.js'), 'transpile', '--language=Eiffel']
-      );
-    assert(s.status != 0);
-    assert(s.stderr.includes('Unknown platform Eiffel'), s.stderr);
+    const outcome = runOutput(['transpile', '--language=Eiffel']);
+    assert(outcome.status != 0);
+    assert(outcome.stderr.includes('Unknown platform Eiffel'), outcome.stderr);
     done();
   });
 });

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -44,6 +44,31 @@ module.exports.runSync = function runSync(args) {
 };
 
 /**
+ * Helper to run EOC command line tool and capture everything it produces.
+ *
+ * @param {Array} args - Array of args
+ * @param {Object} options - Extra options for the child process
+ * @return {Object} Stdout, stderr and exit status
+ */
+module.exports.runOutput = function runOutput(args, options = {}) {
+  const {spawnSync} = require('child_process');
+  const outcome = spawnSync(
+    'node',
+    [path.resolve('./src/eoc.js'), '--batch'].concat(args),
+    {
+      'timeout': 1200000,
+      'windowsHide': true,
+      ...options,
+    }
+  );
+  return {
+    'stdout': outcome.stdout.toString(),
+    'stderr': outcome.stderr.toString(),
+    'status': outcome.status,
+  };
+};
+
+/**
  * Assert that all files exist.
  *
  * @param {String} stdout - The stdout printed

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -5,7 +5,7 @@
 
 const assert = require('assert');
 const version = require('../src/version');
-const {runSync, jeoVersion, weAreOnline} = require('./helpers');
+const {runSync, runOutput, jeoVersion, weAreOnline} = require('./helpers');
 
 describe('eoc', () => {
   it('prints its own version', (done) => {
@@ -52,26 +52,22 @@ describe('eoc', () => {
 });
 
 describe('eoc', () => {
-  const {spawnSync} = require('child_process'),
-    path = require('path'),
-    eoc = function(...args) {
-      return spawnSync('node', [path.resolve('./src/eoc.js'), '--batch', ...args]);
-    };
+  const path = require('path');
   it('accepts the "js" alias for the --language option', (done) => {
-    assert.strictEqual(eoc('--language=js', 'clean').status, 0);
+    assert.strictEqual(runOutput(['--language=js', 'clean']).status, 0);
     done();
   });
   it('accepts the full "javascript" name for the --language option', (done) => {
-    assert.strictEqual(eoc('--language=javascript', 'clean').status, 0);
+    assert.strictEqual(runOutput(['--language=javascript', 'clean']).status, 0);
     done();
   });
   it('accepts a mixed-case value for the --language option', (done) => {
-    assert.strictEqual(eoc('--language=JAVA', 'clean').status, 0);
+    assert.strictEqual(runOutput(['--language=JAVA', 'clean']).status, 0);
     done();
   });
   it('rejects an unknown --language value', (done) => {
-    const result = eoc('--language=Eiffel', 'clean');
-    const stderr = result.stderr.toString();
+    const result = runOutput(['--language=Eiffel', 'clean']);
+    const stderr = result.stderr;
     assert.notStrictEqual(result.status, 0);
     assert(
       /^error: option '-l, --language <name>' argument 'Eiffel' is invalid\. Unknown platform Eiffel/.test(stderr),
@@ -82,17 +78,17 @@ describe('eoc', () => {
     done();
   });
   it('accepts the --lints option', (done) => {
-    assert.strictEqual(eoc('--lints=0.0.42', 'clean').status, 0);
+    assert.strictEqual(runOutput(['--lints=0.0.42', 'clean']).status, 0);
     done();
   });
   it('reports a clean error when generate_comments gets an unsupported provider, instead of a raw stack trace', (done) => {
-    const result = eoc(
+    const result = runOutput([
       'generate_comments',
       '--provider=bogus',
       '--source', path.resolve('./src/eoc.js'),
       '--prompt_template', path.resolve('./src/eoc.js')
-    );
-    const stderr = result.stderr.toString();
+    ]);
+    const stderr = result.stderr;
     assert.notStrictEqual(result.status, 0);
     assert(!stderr.includes('Node.js v'), stderr);
     assert(!stderr.includes('node:internal/process/promises'), stderr);
@@ -109,8 +105,8 @@ describe('eoc', () => {
       home = fs.mkdtempSync(path.join(os.tmpdir(), 'eoc-docs-target-')),
       target = path.join(home, 'notadir');
     fs.writeFileSync(target, '');
-    const result = eoc('--target', target, 'docs');
-    const stderr = result.stderr.toString();
+    const result = runOutput(['--target', target, 'docs']);
+    const stderr = result.stderr;
     assert.notStrictEqual(result.status, 0);
     assert(!stderr.includes('Node.js v'), stderr);
     assert(!stderr.includes('node:internal/process/promises'), stderr);
@@ -173,28 +169,23 @@ describe('select', () => {
 });
 
 describe('eoc', () => {
-  const {spawnSync} = require('child_process');
-  const path = require('path');
-  const eoc = function(...args) {
-    return spawnSync('node', [path.resolve('./src/eoc.js'), '--batch', ...args]);
-  };
   it('reports a failing async command cleanly without leaking a stack trace', (done) => {
-    const result = eoc(
+    const result = runOutput([
       'generate_comments', '--provider=no-such-llm',
       '--source=absent.eo', '--prompt_template=absent.txt'
-    );
-    const stderr = result.stderr.toString();
+    ]);
+    const stderr = result.stderr;
     assert.notStrictEqual(result.status, 0);
     assert(stderr.includes('`no-such-llm` provider is not supported'), stderr);
     assert(!/\.js:\d+/.test(stderr), stderr);
     done();
   });
   it('reports a filesystem error from an async command without a stack trace', (done) => {
-    const result = eoc(
+    const result = runOutput([
       'generate_comments', '--provider=placeholder',
       '--source=absent.eo', '--prompt_template=absent.txt'
-    );
-    const stderr = result.stderr.toString();
+    ]);
+    const stderr = result.stderr;
     assert.notStrictEqual(result.status, 0);
     assert(stderr.includes('no such file or directory'), stderr);
     assert(!/\.js:\d+/.test(stderr), stderr);

--- a/test/test_helpers.js
+++ b/test/test_helpers.js
@@ -1,0 +1,38 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+const {runOutput} = require('./helpers');
+
+describe('helpers', () => {
+  it('captures the stderr of a failing command', () => {
+    const outcome = runOutput(['transpile', '--language=Eiffel']);
+    assert(
+      outcome.stderr.includes('Unknown platform Eiffel'),
+      `stderr of a failing command is lost: ${outcome.stderr}`
+    );
+  });
+  it('reports the exit code of a failing command', () => {
+    const outcome = runOutput(['transpile', '--language=Cobol']);
+    assert.notStrictEqual(
+      outcome.status, 0,
+      'a failing command pretends to be successful'
+    );
+  });
+  it('captures the stdout of a successful command', () => {
+    const outcome = runOutput(['--version']);
+    assert(
+      outcome.stdout.trim().length > 0,
+      `stdout of a successful command is empty: ${outcome.stdout}`
+    );
+  });
+  it('runs the command in the given directory', () => {
+    const outcome = runOutput(['--target', '.', 'clean'], {cwd: require('os').tmpdir()});
+    assert(
+      outcome.stderr.includes('Refusing to delete'),
+      `the working directory is ignored: ${outcome.stderr}`
+    );
+  });
+});


### PR DESCRIPTION
Tests invoked `src/eoc.js` in eight different places, each with its own `spawnSync` call. None of them passed a timeout, none passed `windowsHide`, and the four in `test_clean.js` ran the CLI without `--batch` while every other test used it. Two identical copies of the same private `eoc` helper sat in `test_eoc.js` alone.

`test/helpers.js` now has `runOutput`, a sibling of `runSync` that performs one spawn and hands back stdout, stderr and status together, with the timeout and `windowsHide` settings `runSync` already used. Every inline spawn in `test_clean.js`, `test_eoc.js`, `test_transpile.js` and `test_format.js` is collapsed onto it, so a flag added to the helper now reaches all of them. `test/test_helpers.js` covers the helper itself: stderr, exit status, stdout and the working directory it is given.

This is test-only, no product behaviour changes.

Closes #1124