### PR TITLE
#1173: drop the main field that pointed at nothing

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "oop"
   ],
   "license": "MIT",
-  "main": "eoc",
   "name": "eolang",
   "nyc": {
     "all": true,


### PR DESCRIPTION
`"main": "eoc"` named a file that does not exist, so `require('eolang')` failed with `Cannot find module`.

Pointing it at `src/eoc.js` would not help: that file calls `program.parse(process.argv)` when it loads, so requiring the package would run the CLI. This is a command line tool and its entry point is already declared under `bin`, so the field is removed.

Closes #1173
