### PR TITLE
#1166: default print to a directory the pipeline makes

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -227,7 +227,7 @@ program.command('print')
   .option(
     '--print-input <dir>',
     'Directory where XMIR files for translation to EO are taken (relative to --target)',
-    '2-optimize'
+    '1-parse'
   )
   .option(
     '--print-output <dir>',


### PR DESCRIPTION
The default pointed at `2-optimize`, which the current pipeline never creates: a tracked run leaves `1-parse`, `3-lint`, `4-resolve`, `5-pre-transpile` and `5-transpile`. `eo:print` was therefore given a directory that does not exist, printed nothing, and `print.js` reported success anyway.

`1-parse` is the stage `eoc print`'s own `--alone` path already names a few hundred lines further down in the same file.

Closes #1166
