### PR TITLE
#1215: load every object of the program at startup

### DIFF
--- a/inspect/src/main/java/org/eolang/eoc/Inspect.java
+++ b/inspect/src/main/java/org/eolang/eoc/Inspect.java
@@ -8,6 +8,7 @@ package org.eolang.eoc;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.eolang.Phi;
 import org.takes.Take;
 import org.takes.facets.fork.FkRegex;
@@ -25,14 +26,6 @@ import org.takes.rs.RsWithType;
  * the tree of objects that lives in its own memory. Nothing is read from
  * the classpath or from XMIR: the objects are asked directly.</p>
  *
- * @todo #500:60min Load the whole tree of objects at startup.
- *  Right now the only object this server can reach is the root, and it
- *  reaches it lazily through {@link Phi}. A package object learns that a
- *  child exists only when that child is taken by name, so listing
- *  everything under the root is impossible until every object is loaded
- *  into memory once, at startup, the way the session in this issue shows
- *  with its "Loaded 56 objects" line. Load them here and keep them, so
- *  that the verbs below walk a tree that is already there.
  * @since 0.0.0
  */
 public final class Inspect {
@@ -89,12 +82,19 @@ public final class Inspect {
      * @throws IOException If fails
      */
     public void start() throws IOException {
+        final Map<String, Phi> objects =
+            new Universe(System.getProperty("java.class.path")).objects();
         new FtBasic(
             new TkFork(
                 new FkRegex(
                     "/",
                     (Take) req -> new RsWithType.Json(
-                        new RsText(String.format("{\"forma\":\"%s\"}", Phi.Φ.forma()))
+                        new RsText(
+                            String.format(
+                                "{\"forma\":\"%s\",\"loaded\":%d}",
+                                Phi.Φ.forma(), objects.size()
+                            )
+                        )
                     )
                 )
             ),

--- a/inspect/src/main/java/org/eolang/eoc/Universe.java
+++ b/inspect/src/main/java/org/eolang/eoc/Universe.java
@@ -1,0 +1,123 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+package org.eolang.eoc;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.TreeSet;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.eolang.Phi;
+
+/**
+ * Every object of the program, loaded once.
+ *
+ * <p>A package object learns that a child exists only when that child is
+ * taken by name, so a tree reached lazily can never be listed. The names
+ * are therefore read once from the jars on the classpath and every one of
+ * them is taken, which is the only moment the classpath is looked at: from
+ * then on the objects answer for themselves.</p>
+ *
+ * @since 0.0.0
+ */
+final class Universe {
+
+    /**
+     * The classpath to read the names from.
+     */
+    private final String classpath;
+
+    /**
+     * Ctor.
+     * @param path The classpath, as {@code java.class.path} spells it
+     */
+    Universe(final String path) {
+        this.classpath = path;
+    }
+
+    /**
+     * Every object of the program, by the name it goes by.
+     *
+     * <p>An object that refuses to be built is left out rather than
+     * stopping the whole load: this tool exists for programs that do not
+     * run, so one broken object must not hide the rest of them.</p>
+     *
+     * @return The objects
+     * @throws IOException If a jar cannot be read
+     */
+    Map<String, Phi> objects() throws IOException {
+        final Map<String, Phi> found = new LinkedHashMap<>(0);
+        for (final String name : this.names()) {
+            try {
+                found.put(name, Phi.Φ.take(name));
+            // @checkstyle IllegalCatchCheck (1 line)
+            } catch (final RuntimeException ex) {
+                continue;
+            }
+        }
+        return found;
+    }
+
+    /**
+     * The name of every object the jars declare.
+     * @return The names, in the order they sort
+     * @throws IOException If a jar cannot be read
+     */
+    private Collection<String> names() throws IOException {
+        final Collection<String> found = new TreeSet<>();
+        for (final String part : this.classpath.split(File.pathSeparator)) {
+            final File jar = new File(part);
+            if (!part.endsWith(".jar") || !jar.isFile()) {
+                continue;
+            }
+            try (JarFile opened = new JarFile(jar)) {
+                final Enumeration<JarEntry> entries = opened.entries();
+                while (entries.hasMoreElements()) {
+                    final String entry = entries.nextElement().getName();
+                    if (entry.startsWith("org/eolang/EO") && entry.endsWith(".class")
+                        && entry.indexOf('$') < 0) {
+                        found.add(this.eo(entry));
+                    }
+                }
+            }
+        }
+        return found;
+    }
+
+    /**
+     * The name an entry of a jar goes by in EO.
+     *
+     * <p>The inverse of what {@code JavaPath} does on the way in: a package
+     * segment carries an {@code EO_} prefix and the object itself an
+     * {@code EO} one, a dash of the name is written as an underscore and an
+     * underscore of the name as two.</p>
+     *
+     * @param entry The path of the entry inside the jar
+     * @return The name in EO notation, without the leading global package
+     */
+    private String eo(final String entry) {
+        final StringBuilder out = new StringBuilder(entry.length());
+        for (final String segment
+            : entry.substring("org/eolang/".length(), entry.length() - ".class".length())
+                .split("/")) {
+            if (out.length() > 0) {
+                out.append('.');
+            }
+            final String name;
+            if (segment.startsWith("EO_")) {
+                name = segment.substring("EO_".length());
+            } else {
+                name = segment.substring("EO".length());
+            }
+            out.append(name.replace("__", " ").replace('_', '-').replace(' ', '_'));
+        }
+        return out.toString();
+    }
+}

--- a/src/commands/java/inspect.js
+++ b/src/commands/java/inspect.js
@@ -89,6 +89,7 @@ module.exports = async function(opts, exec, runner = spawn) {
   const server = runner('java', params, {stdio: 'inherit'});
   try {
     const answer = await ask(port, Date.now() + 60000);
+    console.info(`Loaded ${answer.loaded} objects`);
     console.info('Ready to traverse the Universe');
     console.info(`@ ${answer.forma}`);
   } finally {

--- a/test/commands/test_inspect.js
+++ b/test/commands/test_inspect.js
@@ -64,7 +64,7 @@ describe('inspect/java', () => {
     fs.writeFileSync(path.resolve(home, 'inspect', 'inspect.jar'), '');
     const server = http.createServer((req, res) => {
       res.writeHead(200, {'Content-Type': 'application/json'});
-      res.end('{"forma":"Φ"}');
+      res.end('{"forma":"Φ","loaded":56}');
     });
     await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
     printed = [];
@@ -113,6 +113,12 @@ describe('inspect/java', () => {
   });
   it('kills the server when the session ends', () => {
     assert(killed, 'inspect leaves the server running');
+  });
+  it('prints how many objects were loaded', () => {
+    assert(
+      printed.includes('Loaded 56 objects'),
+      `inspect does not print how many objects were loaded: ${printed}`
+    );
   });
   it('fails fast when javac is not on the PATH', async () => {
     const missing = () => {


### PR DESCRIPTION
A package object learns that a child exists only when that child is taken by name, so nothing could be listed under the root: the server could reach one object, lazily.

`Universe` reads the names once from the jars on the classpath and takes every one of them, which is the only moment the classpath is looked at. From then on the objects answer for themselves, which is what the verbs still to come need. The count goes into the answer and the JavaScript side prints the `Loaded N objects` line the session in #500 shows.

An object that refuses to be built is left out instead of stopping the load, since this tool exists for programs that do not run.

Closes #1215
