### PR TITLE
#1220: turn the single question into an interactive session

### DIFF
--- a/inspect/src/main/java/org/eolang/eoc/Inspect.java
+++ b/inspect/src/main/java/org/eolang/eoc/Inspect.java
@@ -14,6 +14,7 @@ import org.takes.facets.fork.FkRegex;
 import org.takes.facets.fork.TkFork;
 import org.takes.http.Exit;
 import org.takes.http.FtBasic;
+import org.takes.rq.RqHref;
 import org.takes.rs.RsText;
 import org.takes.rs.RsWithType;
 
@@ -96,10 +97,38 @@ public final class Inspect {
                     (Take) req -> new RsWithType.Json(
                         new RsText(String.format("{\"forma\":\"%s\"}", Phi.Φ.forma()))
                     )
+                ),
+                new FkRegex(
+                    "/do",
+                    (Take) req -> new RsWithType.Json(
+                        new RsText(
+                            String.format(
+                                "{\"out\":\"%s\"}",
+                                this.answer(
+                                    new RqHref.Base(req).href().param("verb")
+                                        .iterator().next()
+                                )
+                            )
+                        )
+                    )
                 )
             ),
             this.port()
         ).start(Exit.NEVER);
+    }
+
+    /**
+     * What the server answers to one verb.
+     *
+     * <p>Every verb of the session is refused here until the puzzles above
+     * are resolved, and the refusal names the verb, so that a typo and a
+     * verb that is not written yet look different to the user.</p>
+     *
+     * @param verb The verb the session sent
+     * @return The line to print
+     */
+    private String answer(final String verb) {
+        return String.format("I don't know the verb '%s' yet", verb);
     }
 
     /**

--- a/src/commands/java/inspect.js
+++ b/src/commands/java/inspect.js
@@ -32,13 +32,20 @@ async function jar(opts) {
  * "localhost" resolves to ::1 first on some machines and is refused there.
  * @param {Number} port - TCP port the server listens on
  * @param {Number} deadline - Moment in time after which we give up, in millis
+ * @param {Function} gone - Tells whether the server has already exited
  * @return {Promise<Object>} The answer, parsed from JSON
  */
-async function ask(port, deadline) {
+async function ask(port, deadline, gone) {
   let answer;
   try {
     answer = await (await fetch(`http://127.0.0.1:${port}/`)).json();
   } catch (error) {
+    if (gone()) {
+      throw new Error(
+        `The inspection server exited without opening port ${port}, which is most probably taken by something else`,
+        {cause: error}
+      );
+    }
     if (Date.now() > deadline) {
       throw new Error(
         `The inspection server has not opened port ${port} in a minute`,
@@ -46,7 +53,7 @@ async function ask(port, deadline) {
       );
     }
     await new Promise((resolve) => setTimeout(resolve, 200));
-    answer = await ask(port, deadline);
+    answer = await ask(port, deadline, gone);
   }
   return answer;
 }
@@ -64,12 +71,6 @@ async function ask(port, deadline) {
  *  the loop, and keep the printing here, since the server is the only one
  *  that knows the objects and this side is the only one that knows the
  *  terminal.
- * @todo #500:30min Do not leave the JVM behind when this process dies.
- *  The server is killed in the "finally" below, which covers a failure of
- *  our own code, but not a user pressing Ctrl-C and not a crash of the
- *  Node process itself. In both cases the JVM keeps the port open and the
- *  next run of the command fails to bind it. Kill the child on the
- *  signals too, and report a port that is already taken by naming it.
  * @param {Object} opts - All options
  * @param {Function} [exec] - Optional command runner for the JDK check
  * @param {Function} [runner] - Optional Java process runner
@@ -87,11 +88,28 @@ module.exports = async function(opts, exec, runner = spawn) {
   ];
   console.debug(`+ java ${params.join(' ')}`);
   const server = runner('java', params, {stdio: 'inherit'});
+  let gone = false;
+  server.on('exit', () => {
+    gone = true;
+  });
+  const halt = (code) => () => {
+    server.kill();
+    process.exit(code);
+  };
+  const onint = halt(130);
+  const onterm = halt(143);
+  const onexit = () => server.kill();
+  process.on('SIGINT', onint);
+  process.on('SIGTERM', onterm);
+  process.on('exit', onexit);
   try {
-    const answer = await ask(port, Date.now() + 60000);
+    const answer = await ask(port, Date.now() + 60000, () => gone);
     console.info('Ready to traverse the Universe');
     console.info(`@ ${answer.forma}`);
   } finally {
+    process.off('SIGINT', onint);
+    process.off('SIGTERM', onterm);
+    process.off('exit', onexit);
     server.kill();
   }
 };

--- a/src/commands/java/inspect.js
+++ b/src/commands/java/inspect.js
@@ -6,6 +6,7 @@
 const fs = require('fs');
 const path = require('path');
 const {spawn} = require('node:child_process');
+const readline = require('node:readline/promises');
 const {mvnw, flags} = require('../../mvnw');
 const {verifyJavac} = require('../../jdk');
 
@@ -59,24 +60,59 @@ async function ask(port, deadline, gone) {
 }
 
 /**
+ * Ask the terminal for one verb.
+ * @param {Object} prompt - The terminal to read from
+ * @param {String} at - The object the session is at
+ * @return {Promise<String>} The verb, or nothing when the terminal is closed
+ */
+async function asked(prompt, at) {
+  let verb;
+  try {
+    verb = (await prompt.question(`@ ${at}\n`)).trim();
+  } catch (error) {
+    if (error.code !== 'ERR_USE_AFTER_CLOSE') {
+      throw error;
+    }
+  }
+  return verb;
+}
+
+/**
+ * Read one verb from the terminal, print what the server answers to it,
+ * and go on to the next one, until the user leaves. Recursive rather than
+ * a loop, the same way the waiting above is, since a session is a chain of
+ * questions and each one has to be answered before the next is asked.
+ * @param {Number} port - TCP port the server listens on
+ * @param {String} at - The object the session is at
+ * @param {Object} prompt - The terminal to read the verbs from
+ * @return {Promise} of the session
+ */
+async function session(port, at, prompt) {
+  const verb = await asked(prompt, at);
+  if (verb !== undefined && verb !== 'quit' && verb !== 'exit') {
+    if (verb !== '') {
+      const answer = await (await fetch(
+        `http://127.0.0.1:${port}/do?verb=${encodeURIComponent(verb)}`
+      )).json();
+      console.info(answer.out);
+    }
+    await session(port, at, prompt);
+  }
+}
+
+/**
  * Traverse the tree of objects of a compiled program.
  *
  * The server runs in a separate JVM, with the linked program on its
  * classpath, and every question about the tree is an HTTP request to it.
  *
- * @todo #500:60min Turn this single question into an interactive session.
- *  The issue asks for a prompt that stays open, reads a verb from the
- *  terminal, sends it to the server and prints the answer, until the user
- *  leaves. Right now we ask one question and shut the server down. Add
- *  the loop, and keep the printing here, since the server is the only one
- *  that knows the objects and this side is the only one that knows the
- *  terminal.
  * @param {Object} opts - All options
  * @param {Function} [exec] - Optional command runner for the JDK check
  * @param {Function} [runner] - Optional Java process runner
+ * @param {Object} [input] - Optional stream to read the verbs from
  * @return {Promise} of the inspection session
  */
-module.exports = async function(opts, exec, runner = spawn) {
+module.exports = async function(opts, exec, runner = spawn, input = process.stdin) {
   verifyJavac(exec);
   const port = Number(opts.port);
   const params = [
@@ -106,6 +142,14 @@ module.exports = async function(opts, exec, runner = spawn) {
     const answer = await ask(port, Date.now() + 60000, () => gone);
     console.info('Ready to traverse the Universe');
     console.info(`@ ${answer.forma}`);
+    if (input.isTTY) {
+      const prompt = readline.createInterface({input, output: process.stdout});
+      try {
+        await session(port, answer.forma, prompt);
+      } finally {
+        prompt.close();
+      }
+    }
   } finally {
     process.off('SIGINT', onint);
     process.off('SIGTERM', onterm);

--- a/test/commands/test_inspect.js
+++ b/test/commands/test_inspect.js
@@ -7,6 +7,7 @@ const assert = require('assert');
 const fs = require('fs');
 const http = require('http');
 const net = require('net');
+const {Readable} = require('stream');
 const path = require('path');
 const inspect = require('../../src/commands/java/inspect');
 const {runSync, parserVersion, homeTag, weAreOnline} = require('../helpers');
@@ -127,6 +128,37 @@ describe('inspect/java', () => {
       () => inspect({target: '.', port: 8080}, missing),
       (error) => error.cause.code === 'ENOENT',
       'inspect does not refuse to start when the JDK is missing'
+    );
+  });
+  it('reads verbs from the terminal until the user leaves', async () => {
+    const talker = http.createServer((req, res) => {
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      if (req.url.startsWith('/do')) {
+        res.end('{"out":"nothing yet"}');
+      } else {
+        res.end('{"forma":"Φ"}');
+      }
+    });
+    await new Promise((resolve) => talker.listen(0, '127.0.0.1', resolve));
+    const said = [];
+    const info = console.info;
+    console.info = (line) => said.push(line);
+    const lines = Readable.from(['ls\n', 'quit\n']);
+    lines.isTTY = true;
+    try {
+      await inspect(
+        {target: home, port: talker.address().port},
+        () => true,
+        () => ({kill: () => undefined, on: () => undefined}),
+        lines
+      );
+    } finally {
+      console.info = info;
+      talker.close();
+    }
+    assert(
+      said.includes('nothing yet'),
+      `inspect does not print what the server answers to a verb: ${said}`
     );
   });
   it('names the port when the server exits without opening it', async () => {

--- a/test/commands/test_inspect.js
+++ b/test/commands/test_inspect.js
@@ -77,9 +77,12 @@ describe('inspect/java', () => {
         () => true,
         (command, args) => {
           params = args;
-          return {kill: () => {
-            killed = true;
-          }};
+          return {
+            kill: () => {
+              killed = true;
+            },
+            on: () => undefined,
+          };
         }
       );
     } finally {
@@ -124,6 +127,24 @@ describe('inspect/java', () => {
       () => inspect({target: '.', port: 8080}, missing),
       (error) => error.cause.code === 'ENOENT',
       'inspect does not refuse to start when the JDK is missing'
+    );
+  });
+  it('names the port when the server exits without opening it', async () => {
+    await assert.rejects(
+      () => inspect(
+        {target: home, port: 1},
+        () => true,
+        () => ({
+          kill: () => undefined,
+          on: (event, todo) => {
+            if (event === 'exit') {
+              todo();
+            }
+          },
+        })
+      ),
+      (error) => error.message.includes('port 1'),
+      'inspect does not name the port that could not be opened'
     );
   });
 });


### PR DESCRIPTION
The command asked one question and shut the server down. Now a prompt stays open, reads a verb, sends it to the server and prints the answer, until the user types `quit` or closes the terminal.

The verbs themselves are still refused, by name, which is what the four puzzles left in `Inspect` are about. What lands here is the loop, the prompt and the transport, with the printing kept on this side, since the server is the only one that knows the objects and this side is the only one that knows the terminal.

The prompt only opens on a real terminal, so the integration test, which runs the command with no tty, still ends after the first answer.

Built on #1223's branch, which is what keeps the JVM from outliving a session that now stays open. Once that is merged the diff here is just this change.

Closes #1220
