### PR TITLE
#1172: give each version-up workflow a branch of its own

### DIFF
--- a/.github/workflows/eo-version-up.yml
+++ b/.github/workflows/eo-version-up.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v8
         with:
           sign-commits: true
-          branch: version-up
+          branch: version-up-eo
           commit-message: 'new version of eo maven plugin'
           delete-branch: true
           title: 'New version of EO Maven Plugin'

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v8
         with:
           sign-commits: true
-          branch: version-up
+          branch: version-up-readme
           commit-message: 'new version in README'
           delete-branch: true
           title: 'New version in README'


### PR DESCRIPTION
Both workflows opened a pull request on `version-up`, both with `delete-branch: true`, and both fire on the same push. `peter-evans/create-pull-request` force-updates the named branch to base plus its own changes, so one job's content overwrites the other's, and whichever PR merges first deletes the branch out from under the other.

One branch each: `version-up-readme` for the README bump, `version-up-eo` for `eo-version.txt`.

Closes #1172
