### PR TITLE
#1123: pass the program its arguments unchanged

### DIFF
--- a/src/commands/js/dataize.js
+++ b/src/commands/js/dataize.js
@@ -14,7 +14,7 @@ const eo2jsw = require('../../eo2jsw');
  */
 module.exports = function(obj, args, opts) {
   return eo2jsw(
-    ['dataize', obj, ...args.filter((arg) => !arg.startsWith('-'))],
+    ['dataize', obj, ...args],
     {...opts, alone: true, project: 'project'}
   );
 };


### PR DESCRIPTION
The `js` backend dropped every argument starting with a dash before handing them on, and printed nothing about it. The Java backend passes `...args` through unchanged, so an EO program that reads its own arguments saw a different list depending only on which `--language` was picked.

Both backends now pass them through the same way. The filter was not guarding anything: the arguments go to `execFileSync` as argv entries, so a dash in one of them is not read as a flag of ours.

Closes #1123
