### PR TITLE
#1168: keep the pinned version when Maven Central cannot be reached

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -113,7 +113,7 @@ const path = require('path'),
   jeo = fs.readFileSync(path.join(__dirname, '../jeo-version.txt'), 'utf8').trim();
 let parser = fs.readFileSync(path.join(__dirname, '../eo-version.txt'), 'utf8').trim();
 if (process.argv.includes('--latest')) {
-  parser = require('./parser-version').get();
+  parser = require('./parser-version').get() || parser;
   // Maybe here we should also go to GITHUB, find out what is the
   // latest hash of the objectionary/home repository, and then
   // set it to the "hash" variable?

--- a/src/parser-version.js
+++ b/src/parser-version.js
@@ -8,22 +8,36 @@ const colors = require('colors');
 const request = require('sync-request'),
 
   /**
-   * Load the latest version from GitHub releases.
-   * @return {String} Latest version, for example '0.23.1'
+   * Load the latest version from Maven Central.
+   *
+   * Answers with an empty string when Maven Central cannot be reached or
+   * refuses, the way `exists` below does, so that a machine with no network
+   * keeps the version the repository pins instead of dying on a stack trace
+   * before the command line is even parsed.
+   * @param {function} fetch - HTTP call, defaults to sync-request
+   * @return {String} Latest version, for example '0.23.1', or an empty string
    */
   version = module.exports = {
     value: '',
-    get() {
+    get(fetch = request) {
       if (version.value === '') {
         const repo = 'org/eolang/eo-maven-plugin',
-          url = `https://repo.maven.apache.org/maven2/${repo}/maven-metadata.xml`,
-          res = request('GET', url, {timeout: 100000, socketTimeout: 100000});
-        if (res.statusCode !== 200) {
-          throw new Error(`Invalid response status #${res.statusCode} from ${url}: ${res.body}`);
+          url = `https://repo.maven.apache.org/maven2/${repo}/maven-metadata.xml`;
+        try {
+          const res = fetch('GET', url, {timeout: 100000, socketTimeout: 100000});
+          if (res.statusCode === 200) {
+            version.value = new XMLParser().parse(res.body).metadata.versioning.release;
+            console.info('The latest version of %s at %s is %s', repo, url, version.value);
+          } else {
+            console.warn(colors.yellow(
+              `Cannot ask ${url} for the latest version (HTTP ${res.statusCode}), using the pinned one`
+            ));
+          }
+        } catch (e) {
+          console.warn(colors.yellow(
+            `Cannot ask ${url} for the latest version (${e.message}), using the pinned one`
+          ));
         }
-        const xml = new XMLParser().parse(res.body);
-        version.value = xml.metadata.versioning.release;
-        console.info('The latest version of %s at %s is %s', repo, url, version.value);
       }
       return version.value;
     },

--- a/test/test_parser_version.js
+++ b/test/test_parser_version.js
@@ -16,6 +16,15 @@ describe('parser-version', () => {
       assert(typeof version === 'string');
       assert(/^\d+\.\d+\.\d+$/.test(version), `Version ${version} should match semver pattern`);
     });
+    it('keeps the pinned version when Maven Central is unreachable', () => {
+      parserVersion.value = '';
+      const answered = parserVersion.get(() => {
+        const error = new Error('connect ENETUNREACH');
+        error.code = 'ENETUNREACH';
+        throw error;
+      });
+      assert.strictEqual(answered, '', 'get() must answer with nothing, not throw');
+    });
     it('caches the version after first fetch', () => {
       const first = parserVersion.get();
       const second = parserVersion.get();


### PR DESCRIPTION
`get()` threw on a transport error and on any non-200. It is called at module load, before `parseAsync` runs, so the `try/catch` around the command line never sees it and the user gets a raw stack trace from inside `sync-rpc`.

It now warns and answers with nothing, the way `exists()` next to it was hardened in #998 and #1085, and `--latest` keeps the version the repository pins.

Closes #1168
