### PR TITLE
#1169: say that the JavaScript platform has no such option

### DIFF
--- a/src/eo2jsw.js
+++ b/src/eo2jsw.js
@@ -3,6 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
+const colors = require('colors');
 const path = require('path');
 const {execFileSync} = require('child_process'),
 
@@ -31,6 +32,14 @@ const {execFileSync} = require('child_process'),
    * @return {Promise<Array.<String>>}
    */
   eo2jsw = function(command, args) {
+    const dropped = ['object', 'stack', 'heap'].filter(
+      (name) => process.argv.includes(`--${name}`)
+    );
+    if (dropped.length > 0) {
+      console.warn(colors.yellow(
+        `The JavaScript platform has no ${dropped.map((name) => `--${name}`).join(' and no ')}, ignoring`
+      ));
+    }
     const lib = path.resolve(__dirname, '../node_modules/eo2js/src'),
       bin = path.resolve(lib, 'eo2js.js'),
       cmd = Array.isArray(command) ? command : [command];


### PR DESCRIPTION
`--object`, `--stack` and `--heap` are declared on commands that both platforms serve, and `eo2jsw` builds its flags from a fixed list, so on the JavaScript platform all three were dropped without a word. `eoc -l js test --object foo.app.works` ran the whole suite as if nothing had been asked.

`eo2js` has no per-object filter and runs no JVM, so there is nothing to honour. What was missing was saying so. The check reads `process.argv` rather than the parsed options, because `--stack` and `--heap` carry defaults and would otherwise warn on every run; the same idiom is used for `--latest` in `eoc.js`.

Closes #1169
