### PR TITLE
#1167: let commander parse the object and the arguments

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -302,21 +302,17 @@ program.command('link')
 
 program.command('dataize')
   .description('Run the single executable binary and dataize an object')
+  .argument('<object>', 'Full EO name of the object to dataize')
+  .argument('[args...]', 'Arguments to give to the program being dataized')
   .option('--stack <size>', 'Set stack size for the virtual machine', '64M')
   .option('--heap <size>', 'Set the heap size for the VM', '256M')
-  .action(async (str, opts) => {
+  .action(async (object, args, str) => {
     pin(program.opts());
     clear(str);
     if (program.opts().alone === undefined) {
       await pipe()(coms(), ['register', 'assemble', 'lint', 'resolve', 'transpile', 'compile', 'link'], program.opts());
-      await coms().dataize(
-        program.args[1], program.args.slice(2), {...program.opts(), ...str}
-      );
-    } else {
-      await coms().dataize(
-        program.args[1], program.args.slice(2), {...program.opts(), ...str}
-      );
     }
+    await coms().dataize(object, args, {...program.opts(), ...str});
   });
 
 program.command('inspect')


### PR DESCRIPTION
The command declared `--stack` and `--heap` but no arguments, so commander left those tokens sitting in `program.args` and the code indexed into that array blindly. `eoc dataize --heap 1G foo` took `--heap` for the object name; with the flag written after the name it reached the JVM but also leaked into the program's own argv; and `eoc dataize` with nothing at all ran the jar with no object and exited 0.

Declaring `<object>` and `[args...]` hands all three cases to commander: the options are parsed out wherever they stand, what is left is the program's own arguments, and a missing object name is refused by name.

The duplicated call in the two branches is gone too, since only the pipeline before it differed.

Closes #1167
