### PR TITLE
#1239: pass the foreign flag as two argv entries

### DIFF
--- a/src/eo2jsw.js
+++ b/src/eo2jsw.js
@@ -16,7 +16,7 @@ const {execFileSync} = require('child_process'),
     return [
       '--target', args.target,
       '--project', args.project || 'project',
-      '--foreign eo-foreign.json',
+      '--foreign', 'eo-foreign.json',
       '--resources', path.resolve(lib, 'resources'),
       args.alone ? '--alone' : '',
       args.tests ? '--tests' : ''
@@ -49,3 +49,4 @@ const {execFileSync} = require('child_process'),
   };
 
 module.exports = eo2jsw;
+module.exports.flags = flags;

--- a/test/test_eo2jsw.js
+++ b/test/test_eo2jsw.js
@@ -1,0 +1,16 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+const {flags} = require('../src/eo2jsw');
+
+describe('eo2jsw', () => {
+  it('passes every flag as its own argv entry', () => {
+    const args = flags({target: '.eoc', alone: true}, '/tmp/lib');
+    args.forEach((arg) => assert.ok(!arg.includes(' '), `"${arg}" holds a space`));
+    assert.ok(args.includes('--foreign'));
+    assert.strictEqual(args[args.indexOf('--foreign') + 1], 'eo-foreign.json');
+  });
+});


### PR DESCRIPTION
The flag and its value were joined by a space in one array entry. Under the old
shell invocation the space split them; `execFileSync` has no shell, so `eo2js`
got one literal argument and rejected it, which broke every command on the
JavaScript platform.

Closes #1239
