### PR TITLE
#1244: tick only on an interactive terminal

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -23,6 +23,19 @@ module.exports.summary = function(args) {
 };
 
 /**
+ * Whether the progress ticker should run: it writes cursor-control
+ * escapes, so it only makes sense on an interactive terminal.
+ * @param {Array} args The arguments passed to Maven
+ * @param {String} tgt The target directory, or undefined
+ * @param {Boolean} batch Whether the run is non-interactive
+ * @return {Boolean} TRUE if the ticker should run
+ */
+module.exports.ticking = function(args, tgt, batch) {
+  return tgt !== undefined && args.includes('--quiet') &&
+    !batch && Boolean(process.stdout.isTTY);
+};
+
+/**
  * The shell to use (depending on operating system).
  * @return {String} Path to shell or "undefined" if default one should be used
  */
@@ -119,29 +132,20 @@ module.exports.mvnw = function(args, tgt, batch) {
         shell: shell(),
       }
     );
-    if (tgt !== undefined && args.includes('--quiet')) {
-      if (!batch) {
-        start();
-      }
-      result.on('close', (code) => {
-        if (!batch) {
-          stop();
-        }
-        if (code !== 0) {
-          reject(new Error(`The command "${cmd}" exited with #${code} code`));
-          return;
-        }
-        resolve(args);
-      });
-    } else {
-      result.on('close', (code) => {
-        if (code !== 0) {
-          reject(new Error(`The command "${cmd}" exited with #${code} code`));
-          return;
-        }
-        resolve(args);
-      });
+    const ticking = module.exports.ticking(args, tgt, batch);
+    if (ticking) {
+      start();
     }
+    result.on('close', (code) => {
+      if (ticking) {
+        stop();
+      }
+      if (code !== 0) {
+        reject(new Error(`The command "${cmd}" exited with #${code} code`));
+        return;
+      }
+      resolve(args);
+    });
   });
 };
 

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {mvnw, flags, summary} = require('../src/mvnw');
+const {mvnw, flags, summary, ticking} = require('../src/mvnw');
 const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
@@ -159,5 +159,17 @@ describe('mvnw', () => {
       return curr;
     }
     assert.strictEqual(count(dir, 0), 1, 'count should skip the vanished entry and tally the real class');
+  });
+  it('does not tick when stdout is not a terminal', () => {
+    const was = process.stdout.isTTY;
+    try {
+      process.stdout.isTTY = false;
+      assert.ok(!ticking(['eo:parse', '--quiet'], 'target', false));
+      process.stdout.isTTY = true;
+      assert.ok(ticking(['eo:parse', '--quiet'], 'target', false));
+      assert.ok(!ticking(['eo:parse', '--quiet'], 'target', true));
+    } finally {
+      process.stdout.isTTY = was;
+    }
   });
 });


### PR DESCRIPTION
The progress ticker writes cursor-control escapes once a second with no check
that stdout is a terminal, so a redirected or piped run, which is the normal case
in CI, got the escapes in the file or in the downstream process.

The ticker is gated on `process.stdout.isTTY` now, and the two identical `close`
handlers that differed only in whether they stopped it became one.

Closes #1244
