### PR TITLE
#1241: refuse to write documentation from nothing

### DIFF
--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -9,6 +9,7 @@ const SaxonJS = require('saxon-js');
 const { marked } = require('marked');
 const {elapsed} = require('../elapsed');
 const {findFiles} = require('../files');
+const rel = require('relative');
 
 /**
  * Escape special XML characters.
@@ -122,9 +123,12 @@ function wrapHtml(name, html, css) {
  * @return {Promise<String>} Resolves to the message reporting the summary path
  */
 module.exports = function(opts) {
+  const input = path.resolve(opts.target, '1-parse');
+  if (findFiles(input, '.xmir').length === 0) {
+    throw new Error(`There are no .xmir files in ${rel(input)}, run "eoc parse" first`);
+  }
   return elapsed(async (tracked) => {
     try {
-      const input = path.resolve(opts.target, '1-parse');
       const output = path.resolve(opts.target, 'docs');
       fs.mkdirSync(output, {recursive: true});
       const css = path.join(output, 'styles.css');

--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -124,7 +124,8 @@ function wrapHtml(name, html, css) {
  */
 module.exports = function(opts) {
   const input = path.resolve(opts.target, '1-parse');
-  if (findFiles(input, '.xmir').length === 0) {
+  const usable = !fs.existsSync(opts.target) || fs.statSync(opts.target).isDirectory();
+  if (usable && findFiles(input, '.xmir').length === 0) {
     throw new Error(`There are no .xmir files in ${rel(input)}, run "eoc parse" first`);
   }
   return elapsed(async (tracked) => {

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -21,6 +21,17 @@ describe('docs', () => {
    * Tests that the 'docs' command generates HTML files in the docs directory.
    * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
    */
+  it('refuses to work when nothing was parsed', async () => {
+    fs.rmSync(parsed, {recursive: true, force: true});
+    await assert.rejects(
+      Promise.resolve().then(() => generateDocs({target: home})),
+      (err) => {
+        assert.ok(err.message.includes('run "eoc parse" first'), err.message);
+        return true;
+      }
+    );
+    assert.ok(!fs.existsSync(docs), 'the docs directory must not be written');
+  });
   it('generates HTML files for files and packages', (done) => {
     const sample = path.join(parsed, 'foo', 'bar');
     fs.mkdirSync(sample, {recursive: true});


### PR DESCRIPTION
On a project that had not been parsed, `docs` found no XMIR, wrote a stylesheet,
an empty `packages.html` and a summary claiming zero objects, and exited zero.
Nothing told the user to run `eoc parse` first.

It now fails with a message naming the empty directory, before writing anything.

Closes #1241
