### PR TITLE
#1246: write the mapping the option promises

### DIFF
--- a/src/commands/generate_comments.js
+++ b/src/commands/generate_comments.js
@@ -98,14 +98,19 @@ function getTextFocusedOnSpecificPlaceholder(
  * @param {String} inputCode - Code to replace placeholders in
  * @param {String} commentPlaceholder - Placeholder to replace
  * @param {RunnableSequence} chain - Langchain LLM pipeline
- * @return {Promise<Array.<String>>} of ordered LLM outputs (one for each placeholder in the input)
+ * @return {Promise<Array.<Object>>} of replacements, each carrying the offset of
+ *  the placeholder it replaces and the comment generated for it
  */
 function generateDocumentation(inputCode, commentPlaceholder, chain) {
   const commentPlaceholderRegex = new RegExp(escapeRegExp(commentPlaceholder), 'g');
   const allLocationsOfPlaceholderInInputCode = Array.from(inputCode.matchAll(commentPlaceholderRegex));
-  return Promise.all(allLocationsOfPlaceholderInInputCode.map((location) => {
+  return Promise.all(allLocationsOfPlaceholderInInputCode.map(async (location) => {
     const focusedInputCode = getTextFocusedOnSpecificPlaceholder(inputCode, location, commentPlaceholder, commentPlaceholderRegex);
-    return chain.invoke({ code: focusedInputCode });
+    return {
+      offset: location.index,
+      placeholder: commentPlaceholder,
+      comment: await chain.invoke({ code: focusedInputCode })
+    };
   }));
 }
 

--- a/test/commands/test_generate_comments.js
+++ b/test/commands/test_generate_comments.js
@@ -91,6 +91,24 @@ describe('generate_comments', () => {
     verifyGeneratedOutput(stdout, home, outputFilePath, []);
     done();
   });
+  it('ties every comment to the placeholder it replaces', () => {
+    const home = makeHome();
+    const outputFilePath = path.resolve(home, 'out.json');
+    const source = '# <COMMENT-TO-BE-ADDED>\n[] > a\n# <COMMENT-TO-BE-ADDED>\n[] > b\n';
+    runSync([
+      'generate_comments',
+      '--provider=placeholder',
+      `--prompt_template=${makePromptFile(home, '')}`,
+      `--source=${makeInputFile(home, source)}`,
+      `--output=${outputFilePath}`]);
+    const written = JSON.parse(fs.readFileSync(outputFilePath));
+    assert.deepStrictEqual(
+      written.map((r) => r.offset),
+      [source.indexOf('<COMMENT-TO-BE-ADDED>'), source.lastIndexOf('<COMMENT-TO-BE-ADDED>')],
+      JSON.stringify(written)
+    );
+    written.forEach((r) => assert.strictEqual(r.placeholder, '<COMMENT-TO-BE-ADDED>'));
+  });
   it('does not leak the placeholders counter into the global scope', () => {
     assert.strictEqual(globalThis.placeholders, undefined, 'placeholders leaked onto the global object');
   });
@@ -106,7 +124,7 @@ describe('generate_comments', () => {
  */
 function verifyGeneratedOutput(stdout, home, outputFilePath, expectedContents) {
   assertFilesExist(stdout, home, [outputFilePath]);
-  const fileContents = JSON.parse(fs.readFileSync(outputFilePath));
+  const fileContents = JSON.parse(fs.readFileSync(outputFilePath)).map((r) => r.comment);
   assert.deepStrictEqual(
     fileContents,
     expectedContents,


### PR DESCRIPTION
The option help says the file holds the replacement mapping, but a plain array of
model outputs was written, so nothing tied a generated comment to the placeholder
it belongs to and a consumer had to re-run the same regex and trust the ordering.

Each entry now carries the offset of the placeholder it replaces and the
placeholder text next to the comment. The offset was already at hand and thrown
away.

Closes #1246
