### PR TITLE
#1238: report the packages the build depends on

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ You can also do many other things with `eoc` commands
 (the flow is explained in [this blog post][blog]):
 
 <!-- BEGIN COMMANDS SECTION -->
-* `audit` Inspect all packages and report their status
+* `audit` Print the versions of the packages the build depends on
 * `foreign` Inspect and print the list of foreign objects
 * `clean` Delete all temporary files
 * `register` Register all visible EO source files

--- a/src/commands/audit.js
+++ b/src/commands/audit.js
@@ -3,7 +3,28 @@
  * SPDX-License-Identifier: MIT
  */
 
+const fs = require('fs');
+const path = require('path');
 const {mvnw} = require('../mvnw');
+const version = require('../version');
+
+/**
+ * The packages the build depends on, with the versions resolved for this run.
+ * @param {Hash} opts - All options
+ * @return {Array.<Array.<String>>} of name and version pairs
+ */
+function packages(opts) {
+  return [
+    ['eoc', version.what],
+    ['eo-maven-plugin', opts.parser],
+    ['objectionary/home', opts.homeTag],
+    [
+      'jeo-maven-plugin',
+      opts.jeoVersion ||
+        fs.readFileSync(path.resolve(__dirname, '../../jeo-version.txt'), 'utf8').trim()
+    ]
+  ];
+}
 
 /**
  * Command to audit all packages.
@@ -11,5 +32,10 @@ const {mvnw} = require('../mvnw');
  * @return {Promise} of audit task
  */
 module.exports = function(opts) {
+  packages(opts).forEach(([name, ver]) => {
+    console.info(`${name}: ${ver === undefined ? 'not resolved' : ver}`);
+  });
   return mvnw(['--version'], null, opts.batch);
 };
+
+module.exports.packages = packages;

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -169,7 +169,7 @@ program.hook('preAction', (command) => {
 });
 
 program.command('audit')
-  .description('Inspect all packages and report their status')
+  .description('Print the versions of the packages the build depends on')
   .action(async (str, opts) => {
     pin(program.opts());
     await coms().audit(program.opts());

--- a/test/commands/test_audit.js
+++ b/test/commands/test_audit.js
@@ -5,11 +5,21 @@
 
 const assert = require('assert');
 const {runSync} = require('../helpers');
+const audit = require('../../src/commands/audit');
 
 describe('audit', () => {
-  it('audits all packages', (done) => {
+  it('prints the version of every package', (done) => {
     const stdout = runSync(['audit']);
+    ['eoc:', 'eo-maven-plugin:', 'objectionary/home:', 'jeo-maven-plugin:'].forEach((name) => {
+      assert(stdout.includes(name), stdout);
+    });
     assert(stdout.includes('Apache Maven'), stdout);
+    done();
+  });
+  it('resolves the version of every package', (done) => {
+    audit.packages({parser: '0.62.1', homeTag: '0.62.1'}).forEach(([name, ver]) => {
+      assert(ver !== undefined && ver !== '', `${name} is not resolved`);
+    });
     done();
   });
 });


### PR DESCRIPTION
`audit` ran `mvnw --version` and printed nothing else, so it reported the Maven
banner instead of anything about packages, while the README promised a status
report. The test pinned the banner in place.

It now prints the version resolved for this run of every package the build
depends on: eoc itself, the parser, the `objectionary/home` tag and the JEO
plugin, which also covers the parser version asked for in #68. The Maven banner
stays after them. The command description and the README say what it does.

Closes #1238
