### PR TITLE
fix(#1259): quote Maven arguments literally for PowerShell

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -23,6 +23,16 @@ module.exports.summary = function(args) {
 };
 
 /**
+ * Quote a parameter for PowerShell, where single quotes are the literal
+ * form and an embedded quote is doubled.
+ * @param {String} param The parameter to put into the command line
+ * @return {String} The parameter, quoted so that nothing in it expands
+ */
+module.exports.quoted = function(param) {
+  return `'${param.replace(/'/g, `''`)}'`;
+};
+
+/**
  * The shell to use (depending on operating system).
  * @return {String} Path to shell or "undefined" if default one should be used
  */
@@ -112,7 +122,7 @@ module.exports.mvnw = function(args, tgt, batch) {
     console.debug('+ %s', cmd);
     const result = spawn(
       bin,
-      process.platform === 'win32' ? params.map((p) => `"${p}"`) : params,
+      process.platform === 'win32' ? params.map(module.exports.quoted) : params,
       {
         cwd: home,
         stdio: 'inherit',

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {mvnw, flags, summary} = require('../src/mvnw');
+const {mvnw, flags, summary, quoted} = require('../src/mvnw');
 const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
@@ -159,5 +159,25 @@ describe('mvnw', () => {
       return curr;
     }
     assert.strictEqual(count(dir, 0), 1, 'count should skip the vanished entry and tally the real class');
+  });
+  it('keeps a dollar sign in a quoted parameter', () => {
+    assert.strictEqual(quoted('-Deo.sourcesDir=/proj/a$b/src'), "'-Deo.sourcesDir=/proj/a$b/src'");
+  });
+  it('keeps a backtick in a quoted parameter', () => {
+    assert.strictEqual(quoted('-Deo.targetDir=/proj/a`n/t'), "'-Deo.targetDir=/proj/a`n/t'");
+  });
+  it('doubles a single quote inside a quoted parameter', () => {
+    assert.strictEqual(quoted("a'b"), "'a''b'");
+  });
+  it('passes a dollar sign through the shell untouched', function () {
+    if (process.platform !== 'win32') {
+      this.skip();
+    }
+    this.timeout(60000);
+    const arg = `-Deo.sourcesDir=C:${String.fromCharCode(92)}a$b`;
+    const out = execSync(
+      `powershell.exe -NoProfile -Command Write-Output ${quoted(arg)}`
+    ).toString().trim();
+    assert.strictEqual(out, arg);
   });
 });


### PR DESCRIPTION
Fixes #1259.

On Windows the Maven arguments were wrapped in double quotes before being pasted into a PowerShell command line. Double quotes are the interpolating form there, so `$b` in a directory name was read as a variable and dropped, and a backtick was read as an escape.

The arguments are now wrapped in single quotes, the literal form, with an embedded quote doubled. Nothing in a path expands any more.

Tests cover the quoting itself and, on Windows only, a real round trip through `powershell.exe` for a path holding `$`.
