### PR TITLE
fix(#1260): resolve the Windows shell through SystemRoot

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -23,14 +23,21 @@ module.exports.summary = function(args) {
 };
 
 /**
- * The shell to use (depending on operating system).
+ * The shell to use (depending on operating system). On Windows the location
+ * comes from %SystemRoot%, because Windows is not always installed in
+ * "C:\Windows", and the shell is the native one under System32. When that
+ * file is not there, the bare name is left for PATH to resolve.
  * @return {String} Path to shell or "undefined" if default one should be used
  */
-function shell() {
+module.exports.shell = function() {
   if (process.platform === 'win32') {
-    return 'C:\\Windows\\SysWOW64\\WindowsPowerShell\\v1.0\\powershell.exe';
+    const own = path.join(
+      process.env.SystemRoot || 'C:\\Windows',
+      'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe'
+    );
+    return fs.existsSync(own) ? own : 'powershell.exe';
   }
-}
+};
 
 let beginning,
   phase = 'unknown',
@@ -116,7 +123,7 @@ module.exports.mvnw = function(args, tgt, batch) {
       {
         cwd: home,
         stdio: 'inherit',
-        shell: shell(),
+        shell: module.exports.shell(),
       }
     );
     if (tgt !== undefined && args.includes('--quiet')) {

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {mvnw, flags, summary} = require('../src/mvnw');
+const {mvnw, flags, summary, shell} = require('../src/mvnw');
 const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
@@ -159,5 +159,39 @@ describe('mvnw', () => {
       return curr;
     }
     assert.strictEqual(count(dir, 0), 1, 'count should skip the vanished entry and tally the real class');
+  });
+  it('takes the shell from the system root', function () {
+    if (process.platform !== 'win32') {
+      this.skip();
+    }
+    const root = process.env.SystemRoot;
+    try {
+      process.env.SystemRoot = root;
+      assert.strictEqual(
+        shell(),
+        path.join(root, 'System32', 'WindowsPowerShell', 'v1.0', 'powershell.exe')
+      );
+      assert.ok(fs.existsSync(shell()));
+    } finally {
+      process.env.SystemRoot = root;
+    }
+  });
+  it('falls back to the name on PATH when the system root is wrong', function () {
+    if (process.platform !== 'win32') {
+      this.skip();
+    }
+    const root = process.env.SystemRoot;
+    try {
+      process.env.SystemRoot = path.join(os.tmpdir(), 'no-such-windows');
+      assert.strictEqual(shell(), 'powershell.exe');
+    } finally {
+      process.env.SystemRoot = root;
+    }
+  });
+  it('leaves the shell undefined outside Windows', function () {
+    if (process.platform === 'win32') {
+      this.skip();
+    }
+    assert.strictEqual(shell(), undefined);
   });
 });


### PR DESCRIPTION
Fixes #1260.

The shell was a literal `C:\Windows\SysWOW64\WindowsPowerShell\v1.0\powershell.exe`. That assumes Windows lives on `C:` and names the 32-bit subsystem directory, which does not exist on a 32-bit install at all.

The location now comes from `%SystemRoot%` and points at `System32`, the native shell. When the file is not there the bare `powershell.exe` is left for PATH to resolve, so a machine with an unusual layout still runs.

Tests check the resolved path on Windows and the fallback when the root is wrong, plus that nothing is picked on other platforms.
