### PR TITLE
fix(#1261): check the metadata before reading a release out of it

### DIFF
--- a/src/parser-version.js
+++ b/src/parser-version.js
@@ -9,20 +9,28 @@ const request = require('sync-request'),
 
   /**
    * Load the latest version from GitHub releases.
+   * @param {function} fetch - HTTP call, defaults to sync-request
    * @return {String} Latest version, for example '0.23.1'
    */
   version = module.exports = {
     value: '',
-    get() {
+    get(fetch = request) {
       if (version.value === '') {
         const repo = 'org/eolang/eo-maven-plugin',
           url = `https://repo.maven.apache.org/maven2/${repo}/maven-metadata.xml`,
-          res = request('GET', url, {timeout: 100000, socketTimeout: 100000});
+          res = fetch('GET', url, {timeout: 100000, socketTimeout: 100000});
         if (res.statusCode !== 200) {
           throw new Error(`Invalid response status #${res.statusCode} from ${url}: ${res.body}`);
         }
-        const xml = new XMLParser().parse(res.body);
-        version.value = xml.metadata.versioning.release;
+        const xml = new XMLParser({parseTagValue: false}).parse(res.body),
+          versioning = xml && xml.metadata ? xml.metadata.versioning : undefined,
+          release = versioning ? versioning.release : undefined;
+        if (release === undefined || release === null || release === '') {
+          throw new Error(
+            `No <release> in the metadata at ${url}: ${String(res.body).slice(0, 200)}`
+          );
+        }
+        version.value = String(release);
         console.info('The latest version of %s at %s is %s', repo, url, version.value);
       }
       return version.value;

--- a/test/test_parser_version.js
+++ b/test/test_parser_version.js
@@ -16,6 +16,47 @@ describe('parser-version', () => {
       assert(typeof version === 'string');
       assert(/^\d+\.\d+\.\d+$/.test(version), `Version ${version} should match semver pattern`);
     });
+    it('complains about a 200 that is not the metadata', () => {
+      const cached = parserVersion.value;
+      parserVersion.value = '';
+      try {
+        assert.throws(
+          () => parserVersion.get(() => ({statusCode: 200, body: '<html>proxy notice</html>'})),
+          /No <release> in the metadata at https:/,
+          'a body without metadata must be reported, not dereferenced'
+        );
+      } finally {
+        parserVersion.value = cached;
+      }
+    });
+    it('complains about metadata without a release element', () => {
+      const cached = parserVersion.value;
+      parserVersion.value = '';
+      try {
+        assert.throws(
+          () => parserVersion.get(
+            () => ({statusCode: 200, body: '<metadata><versioning/></metadata>'})
+          ),
+          /No <release> in the metadata/,
+          'metadata without a release must be reported'
+        );
+      } finally {
+        parserVersion.value = cached;
+      }
+    });
+    it('keeps a two-part release as a string', () => {
+      const cached = parserVersion.value;
+      parserVersion.value = '';
+      try {
+        const got = parserVersion.get(() => ({
+          statusCode: 200,
+          body: '<metadata><versioning><release>1.0</release></versioning></metadata>'
+        }));
+        assert.strictEqual(got, '1.0', 'a numeric-looking release must stay a string');
+      } finally {
+        parserVersion.value = cached;
+      }
+    });
     it('caches the version after first fetch', () => {
       const first = parserVersion.get();
       const second = parserVersion.get();


### PR DESCRIPTION
Fixes #1261.

`get()` checked the HTTP status and then read `xml.metadata.versioning.release` with no check at all. A `200` carrying something other than `maven-metadata.xml` (a proxy notice, a truncated body) came out as `TypeError: Cannot read properties of undefined`, and metadata without a `<release>` quietly produced `undefined`, which then travelled into a POM URL and into `-Deo.version=`.

The document is now checked before it is read through, and the failure names the URL and the beginning of the body, in the shape the neighbouring status check already uses.

`parseTagValue: false` goes with it: `fast-xml-parser` turns a two-part release such as `1.0` into the number `1`, which would be interpolated into a URL that does not exist.

`get()` takes the HTTP call as an argument now, the way `exists()` already did, so the new tests do not need the network.
