### PR TITLE
fix(#1262): link the stylesheet relative to the page that carries it

### DIFF
--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -75,10 +75,22 @@ function createXmirHtmlBlock(filepath) {
 }
 
 /**
+ * The stylesheet link of a page, relative to the directory that page
+ * is written into, with forward slashes, since a URL wants them on
+ * every platform.
+ * @param {String} page - Path of the HTML file being written
+ * @param {String} css - Path of the stylesheet
+ * @return {String} The value for the "href" attribute
+ */
+function cssLink(page, css) {
+  return path.relative(path.dirname(page), css).split(path.sep).join('/');
+}
+
+/**
  * Generates Package HTML
  * @param {String} name - Package name
  * @param {String[]} htmls - Array of xmirs htmls
- * @param {String} css - CSS file path
+ * @param {String} css - Stylesheet link, relative to the page
  * @return {String} HTML of the package
  */
 function generatePackageHtml(name, htmls, css) {
@@ -109,7 +121,7 @@ function generatePackageHtml(name, htmls, css) {
  * Wraps given html body
  * @param {String} name - File name
  * @param {String} html - HTML body
- * @param {String} css - CSS file path
+ * @param {String} css - Stylesheet link, relative to the page
  * @return {String} Ready HTML
  */
 function wrapHtml(name, html, css) {
@@ -138,7 +150,7 @@ module.exports = function(opts) {
         const xmir_html = createXmirHtmlBlock(xmir);
         const html_app = path.join(output, path.dirname(relative),`${name}.html`);
         fs.mkdirSync(path.dirname(html_app), {recursive: true});
-        fs.writeFileSync(html_app, wrapHtml(name, xmir_html, css));
+        fs.writeFileSync(html_app, wrapHtml(name, xmir_html, cssLink(html_app, css)));
         const package_dir = path.dirname(relative);
         if (package_dir !== '.') {
           const package_name = package_dir.split(path.sep).join('.');
@@ -161,10 +173,13 @@ module.exports = function(opts) {
       for (const [package_name, info] of packages_info) {
         fs.mkdirSync(path.dirname(info.path), {recursive: true});
         fs.writeFileSync(info.path,
-          generatePackageHtml(`${package_name} package`, info.xmir_htmls, css));
+          generatePackageHtml(`${package_name} package`, info.xmir_htmls, cssLink(info.path, css)));
       }
       const packages = path.join(output, 'packages.html');
-      fs.writeFileSync(packages, generatePackageHtml('overall package', all_xmir_htmls, css));
+      fs.writeFileSync(
+        packages,
+        generatePackageHtml('overall package', all_xmir_htmls, cssLink(packages, css))
+      );
       const summary = path.join(output, 'summary.xml');
       const lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -45,6 +45,23 @@ describe('docs', () => {
     assert(fs.existsSync(packages_html), `Expected file ${packages_html} but it was not created`);
     const css_html = path.join(docs, 'styles.css');
     assert(fs.existsSync(css_html), `Expected file ${css_html} but it was not created`);
+    const nested = fs.readFileSync(test1_html, 'utf-8');
+    assert(
+      nested.includes('<link href="../../styles.css"'),
+      `Expected a relative stylesheet link in ${test1_html}, got: ${nested.slice(0, 200)}`
+    );
+    const top = fs.readFileSync(packages_html, 'utf-8');
+    assert(
+      top.includes('<link href="styles.css"'),
+      `Expected a relative stylesheet link in ${packages_html}, got: ${top.slice(0, 200)}`
+    );
+    for (const page of [test1_html, test2_html, package_foo_bar_html, packages_html]) {
+      const body = fs.readFileSync(page, 'utf-8');
+      assert(
+        !/<link href="[^"]*[\\:]/.test(body),
+        `Stylesheet link in ${page} is a filesystem path, not a URL: ${body.slice(0, 200)}`
+      );
+    }
     done();
   });
   /**


### PR DESCRIPTION
Fixes #1262.

Every generated page carried the stylesheet as an absolute filesystem path. On Linux that only resolves on the machine that produced it; on Windows it is `C:\...` with backslashes, which a browser cannot read as a URL at all.

The link is now computed per page, relative to the directory the page is written into, with forward slashes. Object pages sit one or more levels below `docs`, so each gets its own value.

The existing docs test now also asserts the link is relative and holds no drive letter or backslash.
