### PR TITLE
fix(#1263): ask whether a parser version is comparable before comparing it

### DIFF
--- a/src/commands/lint.js
+++ b/src/commands/lint.js
@@ -61,7 +61,10 @@ module.exports.goals = goals;
 module.exports.extras = extras;
 
 function goals(opts) {
-  if (opts.parser.endsWith('-SNAPSHOT') || semver.gte(opts.parser, '0.45.0')) {
+  if (
+    opts.parser.endsWith('-SNAPSHOT')
+    || (semver.valid(opts.parser) !== null && semver.gte(opts.parser, '0.45.0'))
+  ) {
     return ['eo:lint'];
   }
   return ['eo:verify'];

--- a/test/commands/test_lint.js
+++ b/test/commands/test_lint.js
@@ -12,6 +12,23 @@ const {runSync, assertFilesExist, parserVersion, homeTag, weAreOnline} = require
 const simple = ['+architect yegor256@gmail.com', '', '[] > simple', ''].join('\n');
 
 describe('lint', () => {
+  it('picks a goal for a version semver cannot parse', () => {
+    for (const parser of ['0.57', '1.0-rc1', '0.57.3.1', 'latest', '']) {
+      assert.deepEqual(
+        lint.goals({parser}),
+        ['eo:verify'],
+        `Expected a goal rather than a TypeError for --parser ${parser}`
+      );
+    }
+  });
+  it('picks the linting goal for a modern parser', () => {
+    assert.deepEqual(lint.goals({parser: '0.57.3'}), ['eo:lint']);
+    assert.deepEqual(lint.goals({parser: '0.45.0'}), ['eo:lint']);
+    assert.deepEqual(lint.goals({parser: '0.57-SNAPSHOT'}), ['eo:lint']);
+  });
+  it('picks the verifying goal for an older parser', () => {
+    assert.deepEqual(lint.goals({parser: '0.44.0'}), ['eo:verify']);
+  });
   it('extras returns failOnWarning flag', (done) => {
     assert.deepEqual(lint.extras({easy: false}), ['-Deo.failOnWarning=true']);
     assert.deepEqual(lint.extras({easy: true}), ['-Deo.failOnWarning=false']);


### PR DESCRIPTION
Fixes #1263.

`eoc lint --parser 0.57` died with `TypeError: Invalid Version: 0.57` thrown from inside `semver`, naming neither the option nor what was wrong with it. `semver.gte` accepts only a strict three-part version, and `goals()` handed it whatever the user typed.

`semver.valid` returns `null` instead of throwing, so an unparseable version now falls through to `eo:verify`. The check that already exists in `mvnw.js` then reports the version as unavailable in Maven Central, naming the option and pointing at the directory listing, which is the message the user should have been getting all along.

Tests cover the values that used to throw and the ones that must keep choosing `eo:lint`.
