### PR TITLE
fix(#1265): state the output limit of phino and name the file that hits it

### DIFF
--- a/src/commands/normalize.js
+++ b/src/commands/normalize.js
@@ -18,6 +18,32 @@ const relative = require('relative');
  * @param {Object} opts - All options
  * @return {Promise} of normalize task
  */
+/**
+ * The largest output a single XMIR may produce, in bytes. Node caps the
+ * stdout of a synchronous child at 1 MiB by default, and the parsed XMIR of
+ * the runtime is already halfway there before normalization.
+ */
+const MAX_OUTPUT = 64 * 1024 * 1024;
+
+/**
+ * Rewrite one XMIR through phino.
+ * @param {String} xmir - Path of the XMIR to rewrite
+ * @param {String} rel - Path of that XMIR relative to the parsed directory
+ * @param {function} run - Child process call, defaults to execFileSync
+ * @return {Buffer} The normalized XMIR
+ */
+function normalized(xmir, rel, run = execFileSync) {
+  try {
+    return run(
+      'phino',
+      ['rewrite', '--input=xmir', '--output=xmir', '--normalize', xmir],
+      {stdio: ['pipe', 'pipe', 'pipe'], maxBuffer: MAX_OUTPUT}
+    );
+  } catch (e) {
+    throw new Error(`Failed to normalize ${rel}: ${e.message}`, {cause: e});
+  }
+}
+
 module.exports = function(opts) {
   if (opts.sources === undefined) {
     throw new Error('Sources directory is not specified. Please provide it with --sources option.');
@@ -42,11 +68,7 @@ module.exports = function(opts) {
       const rel = path.relative(parsed, xmir);
       console.debug('Normalizing %s', rel);
       const ts = Date.now();
-      const out = execFileSync(
-        'phino',
-        ['rewrite', '--input=xmir', '--output=xmir', '--normalize', xmir],
-        {stdio: ['pipe', 'pipe', 'pipe']}
-      );
+      const out = normalized(xmir, rel);
       console.debug('Normalized in %dms', Date.now() - ts);
       saveFile(normed, rel, out);
     }
@@ -63,3 +85,5 @@ module.exports = function(opts) {
     return r;
   });
 };
+
+module.exports.normalized = normalized;

--- a/test/commands/test_normalize.js
+++ b/test/commands/test_normalize.js
@@ -8,6 +8,7 @@ const fs = require('fs');
 const path = require('path');
 const {execSync} = require('child_process');
 const {runSync, parserVersion, homeTag, weAreOnline} = require('../helpers');
+const {normalized} = require('../../src/commands/normalize');
 
 const eo = '[] > simple\n';
 
@@ -104,5 +105,41 @@ describe('normalize', () => {
     const normalized = fs.readFileSync(path.resolve(source, 'simple.eo'), 'utf8');
     assert(normalized.length > 0, 'Normalized .eo file must not be empty');
     done();
+  });
+});
+
+describe('normalized', () => {
+  it('gives the child room beyond the default one megabyte', () => {
+    let opts;
+    normalized('/tmp/foo.xmir', 'foo.xmir', (bin, args, options) => {
+      opts = options;
+      return Buffer.alloc(0);
+    });
+    assert.ok(
+      opts.maxBuffer > 1024 * 1024,
+      `Expected a cap above the 1 MiB default, got ${opts.maxBuffer}`
+    );
+  });
+  it('names the file it was normalizing when the child fails', () => {
+    assert.throws(
+      () => normalized('/tmp/foo.xmir', 'org/eolang/directory.xmir', () => {
+        const error = new Error('stdout maxBuffer length exceeded');
+        error.code = 'ENOBUFS';
+        throw error;
+      }),
+      /Failed to normalize org\/eolang\/directory\.xmir: stdout maxBuffer length exceeded/,
+      'the failure must name the XMIR that caused it'
+    );
+  });
+  it('keeps the original failure as the cause', () => {
+    const original = new Error('phino died');
+    try {
+      normalized('/tmp/foo.xmir', 'foo.xmir', () => {
+        throw original;
+      });
+      assert.fail('expected a failure');
+    } catch (e) {
+      assert.strictEqual(e.cause, original);
+    }
   });
 });


### PR DESCRIPTION
Fixes #1265.

The `phino` call inherited Node's default 1 MiB cap on a synchronous child's stdout. The parsed XMIR of `eo-runtime` already reaches 571 KB before normalization, so the cap is close, and crossing it killed the command with `stdout maxBuffer length exceeded` without naming the file being rewritten.

The limit is now stated at 64 MiB, two orders above the largest XMIR the runtime produces, so it guards against a runaway rather than against ordinary work. A failure of the child is wrapped with the XMIR it was rewriting, keeping the original as the cause.

The rewrite moved into a small exported function so the tests can drive it without `phino` installed.
