### PR TITLE
fix(#1266): refuse a port that is not a TCP port instead of waiting on it

### DIFF
--- a/src/commands/java/inspect.js
+++ b/src/commands/java/inspect.js
@@ -78,6 +78,9 @@ async function ask(port, deadline) {
 module.exports = async function(opts, exec, runner = spawn) {
   verifyJavac(exec);
   const port = Number(opts.port);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new Error(`Port "${opts.port}" is not a TCP port between 1 and 65535`);
+  }
   const params = [
     '-cp',
     [path.resolve(opts.target, 'eoc.jar'), await jar(opts)].join(path.delimiter),

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -91,6 +91,23 @@ for (const [alias, canonical] of Object.entries(language)) {
  * @return {String} The canonical platform name
  * @throws {InvalidArgumentError} If the language does not resolve to a known platform
  */
+/**
+ * Turn the raw --port value into a TCP port, rejecting anything that is not
+ * one. Without this a value such as "abc" reaches the inspection client as
+ * NaN, makes the request URL unparseable, and is then waited on for a minute
+ * as if the server were slow to start.
+ * @param {String} value - Raw value from the command line
+ * @return {Number} The port
+ * @throws {InvalidArgumentError} If the value is not a TCP port
+ */
+function tcpPort(value) {
+  const port = Number(value);
+  if (!Number.isInteger(port) || port < 1 || port > 65535) {
+    throw new InvalidArgumentError(`must be a TCP port between 1 and 65535, not "${value}"`);
+  }
+  return port;
+}
+
 function canonicalLanguage(value) {
   const canonical = platforms[String(value).toLowerCase()];
   if (canonical === undefined) {
@@ -321,7 +338,7 @@ program.command('dataize')
 
 program.command('inspect')
   .description('Traverse the tree of objects of a compiled program')
-  .option('--port <number>', 'TCP port for the inspection server', '8080')
+  .option('--port <number>', 'TCP port for the inspection server', tcpPort, 8080)
   .action(async (str, opts) => {
     pin(program.opts());
     clear(str);
@@ -469,6 +486,8 @@ module.exports.commandsDescription = function commandsDescription() {
 }
 
 module.exports.canonicalLanguage = canonicalLanguage;
+
+module.exports.tcpPort = tcpPort;
 
 module.exports.select = select;
 

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -94,7 +94,7 @@ for (const [alias, canonical] of Object.entries(language)) {
 /**
  * Turn the raw --port value into a TCP port, rejecting anything that is not
  * one. Without this a value such as "abc" reaches the inspection client as
- * NaN, makes the request URL unparseable, and is then waited on for a minute
+ * NaN, makes the request URL unparsable, and is then waited on for a minute
  * as if the server were slow to start.
  * @param {String} value - Raw value from the command line
  * @return {Number} The port

--- a/test/commands/test_inspect.js
+++ b/test/commands/test_inspect.js
@@ -127,3 +127,15 @@ describe('inspect/java', () => {
     );
   });
 });
+
+describe('inspect', () => {
+  it('refuses a port that is not a TCP port', async () => {
+    await Promise.all(['abc', '99999', '-1'].map((port) => assert.rejects(
+      () => inspect({port, target: 'temp/none'}, () => 'javac 21', () => {
+        throw new Error('no JVM must be started for a bad port');
+      }),
+      /is not a TCP port between 1 and 65535/,
+      `Expected --port ${port} to be refused before the JVM starts`
+    )));
+  });
+});

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -310,3 +310,21 @@ describe('eoc', () => {
     });
   });
 });
+
+describe('tcpPort', () => {
+  const {tcpPort} = require('../src/eoc');
+  it('accepts a port', () => {
+    assert.strictEqual(tcpPort('8080'), 8080);
+    assert.strictEqual(tcpPort('1'), 1);
+    assert.strictEqual(tcpPort('65535'), 65535);
+  });
+  it('rejects what is not a port', () => {
+    for (const value of ['abc', '8080abc', '99999', '-1', '', '80.5']) {
+      assert.throws(
+        () => tcpPort(value),
+        /must be a TCP port between 1 and 65535/,
+        `Expected --port ${value} to be rejected`
+      );
+    }
+  });
+});


### PR DESCRIPTION
Fixes #1266.

`eoc inspect --port abc` spent a minute retrying and then reported that the server had not opened port `NaN`. `Number()` turned the value into `NaN`, the request URL could not be parsed, and `ask()` could not tell that apart from a server that has not bound yet.

`--port` now goes through a parser on the option itself, the way `--language` already does, so commander rejects a bad value at parse time with a message naming the flag. `inspect` repeats the check on its own argument, so a caller that skips the CLI is refused before the JVM is started rather than after the deadline runs out.

Tests cover the values from the table in the issue on both paths.
