### PR TITLE
fix(#1267): escape an object name on its way into the page

### DIFF
--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -95,7 +95,7 @@ function generatePackageHtml(name, htmls, css) {
         <section>
           <header>
             <nav>
-              <h1>${name} documentation</h1>
+              <h1>${xmlEscape(name)} documentation</h1>
               <p>Creation date: ${date.toUTCString()}</p>
             </nav>
           </header>

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -48,6 +48,28 @@ describe('docs', () => {
     done();
   });
   /**
+   * Tests that an ampersand in a name reaches the page as an entity.
+   * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
+   */
+  it('escapes an ampersand in a name', (done) => {
+    fs.writeFileSync(
+      path.join(parsed, 'a&b.xmir'),
+      '<program name="a&amp;b" />'
+    );
+    runSync([
+      'docs',
+      '--verbose',
+      '-s', path.resolve(home, 'src'),
+      '-t', home,
+    ]);
+    const page = fs.readFileSync(path.join(docs, 'a&b.html'), 'utf-8');
+    assert(
+      page.includes('<h1>a&amp;b documentation</h1>'),
+      `Expected the name escaped in the heading, got: ${page.slice(0, 400)}`
+    );
+    done();
+  });
+  /**
    * Tests that a root-level XMIR is not assigned the "." filesystem
    * marker as its package name.
    * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion


### PR DESCRIPTION
Fixes #1267.

Names were escaped on the way into `summary.xml` and left raw on the way into the HTML four lines away, so an object in `a&b.eo` produced `<h1>a&b documentation</h1>`, where `&b ` is an unterminated entity reference.

`generatePackageHtml` now runs the name through the same `xmlEscape` the summary uses. `wrapHtml` passes its name straight through, so the object pages, the package pages and the overall page are all covered by the one change.
