### PR TITLE
fix(#1268): hand the object every argument it was given

### DIFF
--- a/src/commands/java/dataize.js
+++ b/src/commands/java/dataize.js
@@ -22,10 +22,7 @@ module.exports = function(obj, args, opts, exec, runner = spawn) {
     `-Xss${opts.stack}`,
     `-Xmx${opts.heap}`,
     '-jar', path.resolve(opts.target, 'eoc.jar'),
-    opts.verbose ? '--verbose' : '',
-    obj,
-    ...args,
-  ].filter((i) => i);
+  ].concat(opts.verbose ? ['--verbose'] : []).concat([obj]).concat(args);
   console.debug(`+ java ${params.join(' ')}`);
   runner('java', params, {stdio: 'inherit'}).on('close', (code) => {
     if (code !== 0) {

--- a/src/commands/js/dataize.js
+++ b/src/commands/js/dataize.js
@@ -10,11 +10,12 @@ const eo2jsw = require('../../eo2jsw');
  * @param {String} obj - Name of object to dataize
  * @param {Array} args - Arguments
  * @param {Object} opts - All options
+ * @param {Function} [run] - Optional runner, defaults to eo2jsw
  * @return {Promise} of executed command
  */
-module.exports = function(obj, args, opts) {
-  return eo2jsw(
-    ['dataize', obj, ...args.filter((arg) => !arg.startsWith('-'))],
+module.exports = function(obj, args, opts, run = eo2jsw) {
+  return run(
+    ['dataize', obj, ...args],
     {...opts, alone: true, project: 'project'}
   );
 };

--- a/test/commands/test_dataize.js
+++ b/test/commands/test_dataize.js
@@ -83,6 +83,24 @@ describe('dataize', () => {
 });
 
 describe('dataize/java', () => {
+  it('passes an argument that starts with a dash to the object', () => {
+    let params;
+    dataize(
+      'main.foo',
+      ['-5', '', 'x'],
+      {target: '.', stack: '64M', heap: '256M'},
+      () => true,
+      (command, args) => {
+        params = args;
+        return {on: () => true};
+      }
+    );
+    assert.deepStrictEqual(
+      params.slice(params.indexOf('main.foo')),
+      ['main.foo', '-5', '', 'x'],
+      'the arguments of the object must reach it as they were written'
+    );
+  });
   it('sets the maximum Java heap size', () => {
     let params;
     dataize(
@@ -136,6 +154,21 @@ describe('dataize/java', () => {
       () => dataize('main.foo', [], {target: '.', stack: '64M', heap: '256M'}, denied),
       /permission denied while probing javac/,
       'dataize hides the underlying reason why javac could not be executed'
+    );
+  });
+});
+
+describe('dataize/js', () => {
+  const dataizeJs = require('../../src/commands/js/dataize');
+  it('passes an argument that starts with a dash to the object', () => {
+    let params;
+    dataizeJs('main.foo', ['-5', 'x'], {}, (args) => {
+      params = args;
+    });
+    assert.deepStrictEqual(
+      params,
+      ['dataize', 'main.foo', '-5', 'x'],
+      'the arguments of the object must reach it as they were written'
     );
   });
 });


### PR DESCRIPTION
Fixes #1268.

`eoc dataize app -5` handed `-5` to the object on Java and dropped it on JavaScript. The filter reads as an attempt to keep `eoc`'s own flags out, but commander has already taken those out by the time the command is called, so it only reached the program's own arguments.

The filter is gone, and the two languages now agree.

The Java side had a smaller version of the same thing: `.filter((i) => i)` existed to drop the empty string left by `opts.verbose ? '--verbose' : ''`, but it ran over the whole array, so an argument that was an empty string went with it. The flag is built conditionally now and the arguments are concatenated untouched.

The JavaScript command takes its runner as an argument, the way the Java one already did, so both paths are covered by a test.
