### PR TITLE
fix(#1269): give the foreign flag and its value separate argv entries

### DIFF
--- a/src/eo2jsw.js
+++ b/src/eo2jsw.js
@@ -16,7 +16,7 @@ const {execFileSync} = require('child_process'),
     return [
       '--target', args.target,
       '--project', args.project || 'project',
-      '--foreign eo-foreign.json',
+      '--foreign', 'eo-foreign.json',
       '--resources', path.resolve(lib, 'resources'),
       args.alone ? '--alone' : '',
       args.tests ? '--tests' : ''
@@ -49,3 +49,5 @@ const {execFileSync} = require('child_process'),
   };
 
 module.exports = eo2jsw;
+
+module.exports.flags = flags;

--- a/test/test_eo2jsw.js
+++ b/test/test_eo2jsw.js
@@ -1,0 +1,24 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2022-2026 Objectionary.com
+ * SPDX-License-Identifier: MIT
+ */
+
+const assert = require('assert');
+const {flags} = require('../src/eo2jsw');
+
+describe('eo2jsw', () => {
+  it('puts the name of every flag in its own argv entry', () => {
+    for (const entry of flags({target: 'target'}, 'lib')) {
+      assert.ok(
+        !entry.includes(' ') || !entry.startsWith('--'),
+        `The entry "${entry}" holds a flag and its value together, which execFileSync does not split`
+      );
+    }
+  });
+  it('names the foreign catalog as a flag and a value', () => {
+    const args = flags({target: 'target'}, 'lib');
+    const at = args.indexOf('--foreign');
+    assert.notStrictEqual(at, -1, 'the --foreign flag must be an entry of its own');
+    assert.strictEqual(args[at + 1], 'eo-foreign.json');
+  });
+});


### PR DESCRIPTION
Fixes #1269.

`'--foreign eo-foreign.json'` was a single argv entry. `execFileSync` starts no shell, so nothing split it, and `eo2js` received one argument whose text was `--foreign eo-foreign.json` rather than the option carrying the value. The catalog `eoc` meant to name was never the one `eo2js` used.

It is two entries now, like the three flags around it.

`flags` is exported so a test can assert the shape of the vector, including that no entry holds a flag and its value together.
