### PR TITLE
fix(#1270): fold the object path into the test class name

### DIFF
--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -28,10 +28,8 @@ module.exports = function(opts, maven = mvnw) {
       );
     }
     const method = parts.pop().replace(/-/g, '_');
-    const obj = parts.pop().replace(/-/g, '_');
-    const pkg = parts.map((p) => `EO${p.replace(/-/g, '_')}`).join('.');
-    const cls = `EO${obj}*Test`;
-    args.push(`-Dtest=${pkg ? `org.eolang.${pkg}.${cls}` : `org.eolang.${cls}`}#${method}`);
+    const cls = parts.map((p) => `EO${p.replace(/-/g, '_')}`).join('');
+    args.push(`-Dtest=org.eolang.${cls}*Test#${method}`);
   }
   return elapsed(async (tracked) => {
     const result = await maven(

--- a/test/commands/test_test.js
+++ b/test/commands/test_test.js
@@ -124,3 +124,36 @@ describe('test', () => {
     done();
   });
 });
+
+describe('test/java', () => {
+  const javaTest = require('../../src/commands/java/test');
+  /**
+   * Run the command with Maven replaced by a spy.
+   * @param {String} object - Value of the --object option
+   * @return {Promise<Array.<String>>} The arguments Maven was called with
+   */
+  async function selector(object) {
+    let seen;
+    await javaTest(
+      {object, stack: '64M', heap: '256M', target: 'temp/none', sources: 'temp/none'},
+      (args) => {
+        seen = args;
+        return Promise.resolve(args);
+      }
+    );
+    return seen.filter((arg) => arg.startsWith('-Dtest='));
+  }
+  it('folds a package path into the class name', async () => {
+    assert.deepStrictEqual(
+      await selector('string.regex.compile.some-method'),
+      ['-Dtest=org.eolang.EOstringEOregexEOcompile*Test#some_method'],
+      'the transpiler puts every generated test class directly in org.eolang'
+    );
+  });
+  it('keeps working for a top-level object', async () => {
+    assert.deepStrictEqual(
+      await selector('number.plus'),
+      ['-Dtest=org.eolang.EOnumber*Test#plus']
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1270.

`eoc test --object string.regex.compile.some-method` asked surefire for `org.eolang.EOstring.EOregex.EOcompile*Test`, treating the leading segments as packages. The transpiler does not put them there: every generated test class lives directly in `org.eolang` with the whole path folded into the identifier, as `EOstringEOregexEOcompileTest`. Nothing matched, and the run reported no tests rather than reporting that nothing was found.

The segments are folded into the class name now. The single-segment case, which happened to work through the `pkg ?` fallback, produces the same selector as before.

Tests drive the command with Maven replaced by a spy and assert the selector for both shapes.
