### PR TITLE
fix(#1271): guard the loop by its key and refuse an unknown level

### DIFF
--- a/src/tinted-console.js
+++ b/src/tinted-console.js
@@ -39,16 +39,18 @@ for (const level in levels) {
 }
 
 /**
- * Enable this particular logging level.
+ * Enable this particular logging level, and every level above it.
  * @param {String} level - The level to enable
+ * @throws {Error} If the level is not one of the known ones
  */
 module.exports.enable = function enable(level) {
-  for (const key in levels) {
-    if (levels.hasOwnProperty(level)) {
-      levels[key] = true;
-      if (key === level) {
-        break;
-      }
+  if (!Object.hasOwn(levels, level)) {
+    throw new Error(`Unknown logging level: ${level}`);
+  }
+  for (const key of Object.keys(levels)) {
+    levels[key] = true;
+    if (key === level) {
+      break;
     }
   }
 };

--- a/test/test_tinted_console.js
+++ b/test/test_tinted_console.js
@@ -10,4 +10,31 @@ describe('tinted-console', () => {
     require('../src/tinted-console');
     assert.doesNotThrow(() => console.warn('ok'));
   });
+  it('refuses a level it does not know', () => {
+    const {enable} = require('../src/tinted-console');
+    assert.throws(
+      () => enable('nope'),
+      /Unknown logging level: nope/,
+      'an unknown level must be reported, not quietly ignored'
+    );
+  });
+  it('enables the level it is given', () => {
+    const {enable} = require('../src/tinted-console');
+    assert.doesNotThrow(() => enable('debug'));
+    const written = [];
+    const original = process.stdout.write;
+    process.stdout.write = (chunk) => {
+      written.push(String(chunk));
+      return true;
+    };
+    try {
+      console.debug('hello from the test');
+    } finally {
+      process.stdout.write = original;
+    }
+    assert.ok(
+      written.join('').includes('hello from the test'),
+      'an enabled level must print'
+    );
+  });
 });


### PR DESCRIPTION
Fixes #1271.

`enable()` guarded its loop with `hasOwnProperty(level)` — the argument, not the key being visited — so the condition was constant for the whole loop. It skipped no inherited property, which is what the guard is for, and it happened to reject an unknown level as a side effect.

The two jobs are separated now. An unknown level is refused by name, and the walk goes over `Object.keys`, which returns own enumerable keys, so no guard inside the loop is needed.

Without the check on the way in, correcting the typo would have quietly turned an unrecognised level into "enable everything".
