### PR TITLE
fix(#1272): leave console.trace alone

### DIFF
--- a/src/tinted-console.js
+++ b/src/tinted-console.js
@@ -7,7 +7,6 @@ const safe = require('colors/safe');
 const util = require('node:util'),
 
   levels = {
-    'trace': false,
     'debug': false,
     'info': true,
     'warn': true,
@@ -15,7 +14,6 @@ const util = require('node:util'),
   },
 
   colors = {
-    'trace': 'gray',
     'debug': 'gray',
     'info': 'white',
     'warn': 'yellow',

--- a/test/test_tinted_console.js
+++ b/test/test_tinted_console.js
@@ -10,4 +10,27 @@ describe('tinted-console', () => {
     require('../src/tinted-console');
     assert.doesNotThrow(() => console.warn('ok'));
   });
+  it('leaves console.trace printing its stack', () => {
+    require('../src/tinted-console');
+    const written = [];
+    const original = process.stderr.write;
+    process.stderr.write = (chunk) => {
+      written.push(String(chunk));
+      return true;
+    };
+    try {
+      console.trace('looking for the caller');
+    } finally {
+      process.stderr.write = original;
+    }
+    const out = written.join('');
+    assert.ok(
+      out.includes('looking for the caller'),
+      `console.trace printed nothing: ${out}`
+    );
+    assert.ok(
+      out.includes('    at '),
+      `console.trace printed no stack: ${out}`
+    );
+  });
 });


### PR DESCRIPTION
Fixes #1272.

`console.trace` was treated as a severity and replaced with a suppressible wrapper, defaulted to off. It is not a severity: it prints the message together with the stack that led to it, and that is the whole point of it. After the module loaded it did neither, for `eoc` and for every dependency sharing the process, since the module is imported first thing in `src/eoc.js`.

`trace` is dropped from the list of levels and from the colours. `enable('debug')` still walks from the first key, which is now `debug`, so `--verbose` behaves as before.

`console.trace` appears nowhere in `src/`, unlike the other four, which suggests it was listed because it looked like it belonged.
