### PR TITLE
fix(#1273): resolve the latest parser version when a command runs

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -111,15 +111,7 @@ const fs = require('fs');
 const path = require('path'),
   tag = fs.readFileSync(path.join(__dirname, '../home-tag.txt'), 'utf8').trim(),
   jeo = fs.readFileSync(path.join(__dirname, '../jeo-version.txt'), 'utf8').trim();
-let parser = fs.readFileSync(path.join(__dirname, '../eo-version.txt'), 'utf8').trim();
-if (process.argv.includes('--latest')) {
-  parser = require('./parser-version').get();
-  // Maybe here we should also go to GITHUB, find out what is the
-  // latest hash of the objectionary/home repository, and then
-  // set it to the "hash" variable?
-} else {
-  console.debug(`EO parser ${parser}; use the --latest flag if you need a fresher one`);
-}
+const parser = fs.readFileSync(path.join(__dirname, '../eo-version.txt'), 'utf8').trim();
 
 const version = require('./version');
 program
@@ -154,6 +146,19 @@ program
   .option('--verbose', 'Print debug messages and full output of child processes')
   .option('--pin <version>', 'Fail if eoc version doesn\'t match exactly', version.what)
   .option('--update-snapshots', 'Update snapshots in the local repository if they are outdated');
+
+program.hook('preAction', (command) => {
+  if (command.opts().latest) {
+    // Maybe here we should also go to GITHUB, find out what is the
+    // latest hash of the objectionary/home repository, and then
+    // set it to the "hash" variable?
+    command.setOptionValue('parser', require('./parser-version').get());
+  } else {
+    console.debug(
+      `EO parser ${command.opts().parser}; use the --latest flag if you need a fresher one`
+    );
+  }
+});
 
 program.hook('preAction', (command) => {
   const dir = command.opts().dir;

--- a/src/eoc.js
+++ b/src/eoc.js
@@ -112,6 +112,9 @@ const path = require('path'),
   tag = fs.readFileSync(path.join(__dirname, '../home-tag.txt'), 'utf8').trim(),
   jeo = fs.readFileSync(path.join(__dirname, '../jeo-version.txt'), 'utf8').trim();
 const parser = fs.readFileSync(path.join(__dirname, '../eo-version.txt'), 'utf8').trim();
+if (!process.argv.includes('--latest')) {
+  console.debug(`EO parser ${parser}; use the --latest flag if you need a fresher one`);
+}
 
 const version = require('./version');
 program
@@ -153,10 +156,6 @@ program.hook('preAction', (command) => {
     // latest hash of the objectionary/home repository, and then
     // set it to the "hash" variable?
     command.setOptionValue('parser', require('./parser-version').get());
-  } else {
-    console.debug(
-      `EO parser ${command.opts().parser}; use the --latest flag if you need a fresher one`
-    );
   }
 });
 

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -320,3 +320,23 @@ describe('eoc', () => {
     });
   });
 });
+
+describe('eoc', () => {
+  it('does not ask Maven Central for a version when only help was requested', () => {
+    const out = runOutput(['--latest', '--help']);
+    assert.strictEqual(out.status, 0, out.stderr);
+    assert.ok(out.stdout.includes('EO command-line toolkit'), out.stdout);
+    assert.ok(
+      !out.stdout.includes('The latest version of'),
+      `--help must not fetch a version, got: ${out.stdout}`
+    );
+  });
+  it('does not ask Maven Central for a version when only the version was requested', () => {
+    const out = runOutput(['--latest', '--version']);
+    assert.strictEqual(out.status, 0, out.stderr);
+    assert.ok(
+      !out.stdout.includes('The latest version of'),
+      `--version must not fetch a version, got: ${out.stdout}`
+    );
+  });
+});


### PR DESCRIPTION
Fixes #1273.

The `--latest` fetch sat at module scope, behind `process.argv.includes('--latest')`, so it ran while `src/eoc.js` was still loading — for `eoc --latest --help` and `eoc --latest --version` as much as for a build. The request is synchronous with a 100-second timeout, so a slow repository stalled those two with nothing printed, and an unreachable one killed the process before commander was ever reached.

The version is resolved in a `preAction` hook now, next to the one that handles `--dir`. Help and version never reach a hook, and a failure to reach Maven Central belongs to a command that was actually asked to build something.

This also stops matching `--latest` anywhere on the line, so an object argument of that name no longer triggers a fetch.

Both new tests fail on master and pass here.
