### PR TITLE
#1256: run the case once, it does not vary

### DIFF
--- a/test/commands/test_generate_comments.js
+++ b/test/commands/test_generate_comments.js
@@ -54,29 +54,27 @@ describe('generate_comments', () => {
   });
   it('fills output as expected when encountering valid EO code', (done) => {
     const home = makeHome();
-    for (let placeholders = 0; placeholders < 3; ++placeholders) {
-      const exampleInput = [
-        '# <STRUCTURE-BELOW-IS-TO-BE-DOCUMENTED>',
-        '[args] > simple',
-        '  io.stdout (args.at 0) > @',
-        '  # <STRUCTURE-BELOW-IS-TO-BE-DOCUMENTED>',
-        '  [] > current-time',
-        '    output. > @',
-        '      sys.posix',
-        '        "gettimeofday"',
-        '        * sys.posix.timeval'
-      ].join('\n');
-      const outputFilePath = path.resolve(home, 'out.json');
-      const stdout = runSync([
-        'generate_comments',
-        '--provider=placeholder',
-        '--comment_placeholder=<STRUCTURE-BELOW-IS-TO-BE-DOCUMENTED>',
-        `--prompt_template=${makePromptFile(home, '')}`,
-        `--source=${makeInputFile(home, exampleInput)}`,
-        `--output=${outputFilePath}`]);
-      const expectedContents = ['<PLACEHOLDER_RESPONSE>', '<PLACEHOLDER_RESPONSE>'];
-      verifyGeneratedOutput(stdout, home, outputFilePath, expectedContents);
-    }
+    const exampleInput = [
+      '# <STRUCTURE-BELOW-IS-TO-BE-DOCUMENTED>',
+      '[args] > simple',
+      '  io.stdout (args.at 0) > @',
+      '  # <STRUCTURE-BELOW-IS-TO-BE-DOCUMENTED>',
+      '  [] > current-time',
+      '    output. > @',
+      '      sys.posix',
+      '        "gettimeofday"',
+      '        * sys.posix.timeval'
+    ].join('\n');
+    const outputFilePath = path.resolve(home, 'out.json');
+    const stdout = runSync([
+      'generate_comments',
+      '--provider=placeholder',
+      '--comment_placeholder=<STRUCTURE-BELOW-IS-TO-BE-DOCUMENTED>',
+      `--prompt_template=${makePromptFile(home, '')}`,
+      `--source=${makeInputFile(home, exampleInput)}`,
+      `--output=${outputFilePath}`]);
+    const expectedContents = ['<PLACEHOLDER_RESPONSE>', '<PLACEHOLDER_RESPONSE>'];
+    verifyGeneratedOutput(stdout, home, outputFilePath, expectedContents);
     done();
   });
   it('produces empty output when the source carries no placeholder', (done) => {


### PR DESCRIPTION
The loop around this case never reads its variable: the input and the expectation are both
fixed, so all three iterations spawned `node src/eoc.js` with the same arguments and
asserted the same thing. The neighbouring case at `:38` does use the variable, which is
what this one looks like it was copied from.

The case runs once now, 1679ms to 550ms, and it no longer reads as parameterised when it
is not.

Closes #1256
