### PR TITLE
#1290: run itest and grunt on a daily schedule

### DIFF
--- a/.github/workflows/grunt.yml
+++ b/.github/workflows/grunt.yml
@@ -10,6 +10,8 @@ name: grunt
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 4 * * *'
 concurrency:
   group: grunt-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -10,6 +10,8 @@ name: itest
   pull_request:
     branches:
       - master
+  schedule:
+    - cron: '0 4 * * *'
 concurrency:
   group: itest-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
`itest` pulls objects from `objectionary/home` while it runs and `grunt` resolves
`eo-maven-plugin` from Maven Central, so both can turn red without anything here
changing. They ran only on push and on pull request, so nobody learned about it until the
next contributor opened a pull request that had nothing to do with it.

Both now also run at 04:00 UTC, so such a break shows up as a red `master` on its own.

The other half of the report, requiring a branch to be up to date before merging, is a
repository setting and cannot be done from here.

Closes #1290
