### PR TITLE
#1294: Reject missing source directories before register

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -50,6 +50,9 @@ module.exports.flags = function(opts) {
     throw new Error('Target directory is not specified. Please provide it with --target option.');
   }
   const sources = path.resolve(opts.sources);
+  if (!fs.existsSync(sources)) {
+    throw new Error(`Sources directory ${rel(sources)} does not exist.`);
+  }
   console.debug('Sources in %s', rel(sources));
   const target = path.resolve(opts.target);
   console.debug('Target in %s', rel(target));

--- a/test/commands/java/test_pipeline.js
+++ b/test/commands/java/test_pipeline.js
@@ -16,7 +16,7 @@ describe('java/pipeline', () => {
     const maven = function maven(command) {
       calls.push(command);
     }
-    const opts = {sources: 'sources-dir', target: 'target-dir'};
+    const opts = {sources: '.', target: 'target-dir'};
     await pipeline(coms, ['register', 'assemble'], opts, maven)
     assert.deepStrictEqual(
       calls[0],
@@ -50,7 +50,7 @@ describe('java/pipeline', () => {
       calls.push(command);
     }
     const opts = {
-      sources: 'lint-sources-dir',
+      sources: '.',
       target: 'lint-target-dir',
       newParser: true,
       easy: true,
@@ -67,7 +67,7 @@ describe('java/pipeline', () => {
     const maven = function maven(command) {
       calls.push(command);
     }
-    await pipeline(coms, ['resolve'], {sources: 'srs', target: 'tgt'}, maven)
+    await pipeline(coms, ['resolve'], {sources: '.', target: 'tgt'}, maven)
     assert(calls[0].includes('eo:resolve'));
     assert(calls[0].includes('eo:place'));
   });
@@ -85,7 +85,7 @@ describe('java/pipeline', () => {
     const maven = function maven(command) {
       calls.push(command);
     }
-    await pipeline(coms, ['register'], {sources: 'iso-srs', target: 'iso-tgt'}, maven)
+    await pipeline(coms, ['register'], {sources: '.', target: 'iso-tgt'}, maven)
     assert.strictEqual(calls.length, 1, 'accumulator carried commands from another run');
   });
 });

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -17,7 +17,7 @@ describe('mvnw', () => {
   });
   it('sets right flags from options', async () => {
     const opts = {
-      sources: 'sources',
+      sources: '.',
       target: 'target',
       parser: '0.28.11',
       homeTag: 'homeTag'
@@ -26,9 +26,16 @@ describe('mvnw', () => {
     assert.ok(args.includes('-Deo.tag=homeTag'));
     assert.ok(args.includes('-Deo.version=0.28.11'));
   });
+  it('rejects a source path that does not exist', () => {
+    const missing = path.join(os.tmpdir(), `eoc-missing-sources-${Date.now()}`);
+    assert.throws(
+      () => flags({sources: missing, target: 'target'}),
+      /Sources directory .* does not exist\./
+    );
+  });
   it('sets lints version flag from options', () => {
     const opts = {
-      sources: 'sources',
+      sources: '.',
       target: 'target',
       lints: '0.0.42'
     };
@@ -40,7 +47,7 @@ describe('mvnw', () => {
   });
   it('includes slf4j-simple timestamp flags', () => {
     const opts = {
-      sources: 'sources',
+      sources: '.',
       target: 'target',
     };
     const result = flags(opts);
@@ -73,7 +80,7 @@ describe('mvnw', () => {
   });
   it('skips the Maven Central check for SNAPSHOT parser versions', () => {
     const opts = {
-      sources: 'sources',
+      sources: '.',
       target: 'target',
       parser: '1.0-SNAPSHOT',
       homeTag: 'homeTag'


### PR DESCRIPTION
Fixes #1294.

`eoc register` accepted a `--sources` path that did not exist. Maven exits
successfully when there are no inputs to process, so the command printed
`EO objects registered in .../eo-foreign.json` and returned exit code `0` even
though no catalog was created. This made a misspelled path look like a
successful registration and caused the following `foreign` command to fail
with an unrelated missing-file error.

`mvnw.flags()` now resolves the source path and verifies that it exists before
Maven is started. A missing directory raises a clear error, preventing the
success message and non-zero completion from being suppressed. Existing source
directories and empty-directory behavior are unchanged; this check only
rejects an invalid path.

A regression test exercises the flag builder with a guaranteed-absent temporary
path and checks the diagnostic. Existing flag tests now use the repository
directory as their valid source fixture.

Verification:

- `npx mocha test/test_mvnw.js --timeout 1200000` — 15 tests, 0 failures.
