### PR TITLE
#1293: Explain how to create a missing foreign catalog

### DIFF
--- a/src/commands/foreign.js
+++ b/src/commands/foreign.js
@@ -53,6 +53,11 @@ function firstJsonArray(text) {
  */
 module.exports = function(opts) {
   const file = path.resolve(opts.target, 'eo-foreign.json');
+  if (!fs.existsSync(file)) {
+    throw new Error(
+      `There is no ${rel(file)} yet, run "eoc register" first to create it`
+    );
+  }
   const all = JSON.parse(firstJsonArray(fs.readFileSync(file, 'utf8')));
   console.info('There are %d objects in %s:', all.length, rel(file));
   all.forEach((obj) => {

--- a/test/commands/test_foreign.js
+++ b/test/commands/test_foreign.js
@@ -7,9 +7,17 @@ const assert = require('assert');
 const fs = require('fs');
 const path = require('path');
 const {runSync, assertFilesExist, parserVersion, homeTag, weAreOnline} = require('../helpers');
+const foreign = require('../../src/commands/foreign');
 
 describe('foreign', () => {
   before(weAreOnline);
+  it('explains how to create a missing foreign catalog', () => {
+    const target = path.join('temp', `test-foreign-missing-${Date.now()}`);
+    assert.throws(
+      () => foreign({target}),
+      /There is no .*eo-foreign\.json yet, run "eoc register" first to create it/
+    );
+  });
   it('inspects foreign objects and prints a report', (done) => {
     const home = path.resolve('temp/test-foreign/simple');
     fs.rmSync(home, {recursive: true, force: true});


### PR DESCRIPTION
Fixes #1293.

`eoc foreign` attempted to read `eo-foreign.json` unconditionally. On a fresh
or unregistered target this produced Node's raw `ENOENT` message, exposing an
implementation path and leaving the user without the next action. The catalog
is normally created by `eoc register`, so a missing file is an expected setup
state rather than an unexpected system failure.

The command now checks for the catalog before reading it and raises a concise
error that names the relative file and tells the user to run `eoc register`.
Valid catalogs still use the existing parser and report unchanged; malformed
catalog contents continue to receive the existing `No complete JSON array`
diagnostic.

A regression test invokes the command with a missing target and verifies the
actionable message. The existing integration test still confirms inspection of
a registered catalog.

Verification:

- `npx mocha test/commands/test_foreign.js --timeout 1200000` — 2 tests, 0 failures.
