### PR TITLE
#1292: Correct the documented Grunt test scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,8 +156,8 @@ To execute the project tests, use the following command:
 npx grunt
 ```
 
-This command will run all the testing steps, including tests, linting,
-coverage, and more.
+This command runs the Mocha test suite. To run the other checks locally, use
+`npx eslint .` for linting and `npm run coverage` for the coverage report.
 If you only need to run the tests, use:
 
 ```bash


### PR DESCRIPTION
Fixes #1292.

The README described `npx grunt` as running tests, linting, coverage, and
additional checks. The configured Grunt default task is only `mochaTest`, so
the command did not run ESLint and did not create a coverage report. This made
the documented local verification differ from both the actual task graph and
the CI jobs.

The testing section now states exactly what `npx grunt` executes and names the
separate commands for the two checks it does not include: `npx eslint .` for
linting and `npm run coverage` for coverage. The existing `npm test` and
single-file Grunt instructions remain unchanged.

This documentation-only correction keeps the current build behavior intact
while removing the false guarantee that a single Grunt invocation validates
all project quality gates.

Verification:

- `git diff --check` — no whitespace errors.
