### PR TITLE
#1291: Reject inherited names as language values

### DIFF
--- a/src/eoc.js
+++ b/src/eoc.js
@@ -77,7 +77,7 @@ const pipelines = {
  * lower-cased (e.g. `javascript`); `canonicalLanguage()` lower-cases the
  * input, so mixed-case spellings such as `JavaScript` are matched too.
  */
-const platforms = {};
+const platforms = Object.create(null);
 for (const [alias, canonical] of Object.entries(language)) {
   platforms[alias] = canonical;
   platforms[canonical.toLowerCase()] = canonical;

--- a/test/test_eoc.js
+++ b/test/test_eoc.js
@@ -151,6 +151,16 @@ describe('canonicalLanguage', () => {
     );
     done();
   });
+  it('rejects inherited object property names as platforms', () => {
+    assert.throws(
+      () => canonicalLanguage('constructor'),
+      /Unknown platform constructor/
+    );
+    assert.throws(
+      () => canonicalLanguage('__proto__'),
+      /Unknown platform __proto__/
+    );
+  });
 });
 
 describe('select', () => {


### PR DESCRIPTION
Fixes #1291.

The `--language` aliases were stored in a normal object. Since normal objects
inherit from `Object.prototype`, values such as `constructor` and `__proto__`
looked like successful platform lookups and returned a function or prototype
object. The later command selection then failed with a misleading diagnostic
such as `Unknown platform function Object() { [native code] }` instead of
identifying the supplied option value.

The platform lookup is now a prototype-free map. Only explicitly registered
aliases can resolve, so inherited property names follow the same
`InvalidArgumentError` path as any other unknown language while valid aliases
and case-insensitive canonical names remain unchanged.

Regression coverage checks both problematic inherited names and retains the
existing canonicalization and command-selection cases.

Verification:

- `npx mocha test/test_eoc.js --timeout 1200000` — 33 tests, 0 failures.
