### PR TITLE
fix(#1270): select the test class the transpiler actually writes

### DIFF
--- a/src/commands/java/test.js
+++ b/src/commands/java/test.js
@@ -28,10 +28,8 @@ module.exports = function(opts, maven = mvnw) {
       );
     }
     const method = parts.pop().replace(/-/g, '_');
-    const obj = parts.pop().replace(/-/g, '_');
-    const pkg = parts.map((p) => `EO${p.replace(/-/g, '_')}`).join('.');
-    const cls = `TestEO${obj}*`;
-    args.push(`-Dtest=${pkg ? `org.eolang.${pkg}.${cls}` : `org.eolang.${cls}`}#${method}`);
+    const cls = `TestEO${parts[0].replace(/-/g, '_')}*`;
+    args.push(`-Dtest=org.eolang.${cls}#${method}`);
   }
   return elapsed(async (tracked) => {
     const result = await maven(

--- a/test/commands/java/test_test.js
+++ b/test/commands/java/test_test.js
@@ -13,8 +13,8 @@ describe('java/test', () => {
       (args) => { captured = args; }
     );
     assert.ok(
-      captured.includes('-Dtest=org.eolang.EOfoo.TestEOapp*#works_fine'),
-      `expected -Dtest=org.eolang.EOfoo.TestEOapp*#works_fine, got: ${captured}`
+      captured.includes('-Dtest=org.eolang.TestEOfoo*#works_fine'),
+      `expected -Dtest=org.eolang.TestEOfoo*#works_fine, got: ${captured}`
     );
   });
   it('builds -Dtest filter from --object without package', async () => {
@@ -75,8 +75,8 @@ describe('java/test', () => {
       (args) => { captured = args; }
     );
     assert.ok(
-      captured.includes('-Dtest=org.eolang.EOfoo.EObar.TestEOapp*#works_fine'),
-      `expected -Dtest=org.eolang.EOfoo.EObar.TestEOapp*#works_fine, got: ${captured}`
+      captured.includes('-Dtest=org.eolang.TestEOfoo*#works_fine'),
+      `expected -Dtest=org.eolang.TestEOfoo*#works_fine, got: ${captured}`
     );
   });
   it('omits -Dtest when --object is not provided', async () => {


### PR DESCRIPTION
Fixes #1270

`--object` turned every segment before the object into a Java package, so `foo.app.works-fine` asked surefire for `org.eolang.EOfoo.TestEOapp*#works_fine`. The transpiler writes no such package. `JavaPlaced` puts every generated test in `org.eolang` under `Test` plus the java-name of the **top-level** object, one class per top-level object, with the whole subtree folded into it. From a built `eo-runtime`:

```
$ ls target/generated-test-sources/org/eolang/ | head -4
TestEObool.java
TestEObuffer.java
TestEObytes.java
TestEOchunk.java
```

`string/as-number.eo` declares `1000.eq "1e3".as-number ++> can-convert-exponent-text`, and it lands as

```
org/eolang/TestEOstring.java:  void can_convert_exponent_text()
```

so the selector for `string.as-number.can-convert-exponent-text` is `org.eolang.TestEOstring#can_convert_exponent_text`. Nothing about `as-number` appears in the class or the method: the label from `++>` is the whole method name.

The class is now built from the first segment and the method from the last, and the segments in between are ignored, since they are part of neither. A top-level object such as `app.works-fine` is unaffected, which is why the one integration test that exercises `--object` was passing.

The two unit tests that pinned the package-building behaviour are updated to the selector the transpiler makes reachable.
