### PR TITLE
#1312: Reject invalid release API responses

### DIFF
--- a/.github/workflows/eo-version-up.yml
+++ b/.github/workflows/eo-version-up.yml
@@ -21,7 +21,8 @@ jobs:
       - run: sudo apt-get install --yes jq
       - run: |
           curl https://api.github.com/repos/objectionary/eo/releases/latest \
-            --silent | jq -r .tag_name > eo-version.txt
+            --fail --silent --show-error | \
+            jq -er '.tag_name | select(type == "string" and length > 0)' > eo-version.txt
       - uses: peter-evans/create-pull-request@v8
         with:
           sign-commits: true


### PR DESCRIPTION
Closes #1312.

The EO-version workflow now fails on both classes of bad input before `create-pull-request` can run:

- `curl --fail --show-error` turns HTTP/API transport failures into a failed step instead of piping an error body to `jq`;
- `jq -e` plus a non-empty string check rejects missing, null, or empty `tag_name` values.

I verified the jq expression accepts the current shape (`{"tag_name":"0.63.1"}`) and exits non-zero for `{}`, `null`, an empty tag, and a GitHub API error object. The workflow YAML parses successfully locally.
