### PR TITLE
#1309: Await Java dataization process

### DIFF
--- a/src/commands/java/dataize.js
+++ b/src/commands/java/dataize.js
@@ -14,6 +14,7 @@ const {verifyJavac} = require('../../jdk');
  * @param {Object} opts - All options
  * @param {Function} [exec] - Optional command runner for the JDK check
  * @param {Function} [runner] - Optional Java process runner
+ * @return {Promise} Resolves when the JVM exits successfully
  */
 module.exports = function(obj, args, opts, exec, runner = spawn) {
   verifyJavac(exec);
@@ -27,10 +28,15 @@ module.exports = function(obj, args, opts, exec, runner = spawn) {
     ...args,
   ].filter((i) => i);
   console.debug(`+ java ${params.join(' ')}`);
-  runner('java', params, {stdio: 'inherit'}).on('close', (code) => {
-    if (code !== 0) {
-      console.error(`JVM failed with exit code ${code}`);
-      process.exit(1);
-    }
+  const child = runner('java', params, {stdio: 'inherit'});
+  return new Promise((resolve, reject) => {
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+      } else {
+        reject(new Error(`JVM failed with exit code ${code}`));
+      }
+    });
   });
 };

--- a/test/commands/test_dataize.js
+++ b/test/commands/test_dataize.js
@@ -4,6 +4,7 @@
  */
 
 const assert = require('assert');
+const {EventEmitter} = require('events');
 const fs = require('fs');
 const path = require('path');
 const dataize = require('../../src/commands/java/dataize');
@@ -103,6 +104,47 @@ describe('dataize/java', () => {
       !params.some((param) => param.startsWith('-Xms')),
       'dataize still sets the initial Java heap size'
     );
+  });
+  it('waits until the Java process closes successfully', async () => {
+    const child = new EventEmitter();
+    const result = dataize(
+      'main.foo',
+      [],
+      {target: '.', stack: '64M', heap: '256M'},
+      () => true,
+      () => child
+    );
+    assert.strictEqual(
+      await Promise.race([result, Promise.resolve('pending')]),
+      'pending',
+      'dataize completed before the JVM closed'
+    );
+    child.emit('close', 0);
+    await result;
+  });
+  it('rejects when the Java process exits with an error', async () => {
+    const child = new EventEmitter();
+    const result = dataize(
+      'main.foo',
+      [],
+      {target: '.', stack: '64M', heap: '256M'},
+      () => true,
+      () => child
+    );
+    child.emit('close', 7);
+    await assert.rejects(result, /JVM failed with exit code 7/);
+  });
+  it('rejects when the Java process cannot be started', async () => {
+    const child = new EventEmitter();
+    const result = dataize(
+      'main.foo',
+      [],
+      {target: '.', stack: '64M', heap: '256M'},
+      () => true,
+      () => child
+    );
+    child.emit('error', new Error('spawn java denied'));
+    await assert.rejects(result, /spawn java denied/);
   });
   it('fails fast with a clear message when javac is not on the PATH', () => {
     const missing = () => {


### PR DESCRIPTION
Closes #1309.

Java `dataize()` now returns a Promise tied to the spawned JVM instead of returning `undefined` immediately. The Promise stays pending until the child closes, resolves on exit code 0, and rejects on either a non-zero exit code or a child-process `error`.

This makes the existing `await coms().dataize(...)` in `eoc.js` actually wait for JVM completion and lets library callers handle failures without `dataize()` terminating the hosting process itself.

Added focused tests with an `EventEmitter` child stub proving that the Promise does not settle before `close`, and that both non-zero close and process errors reject.

Validation:
- `npx eslint src/commands/java/dataize.js test/commands/test_dataize.js`
- `npx mocha test/commands/test_dataize.js --grep 'dataize/java' --timeout 20000`

Both pass locally.
