### PR TITLE
#1313: Run coverage workflow on pull requests

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,9 @@ name: codecov
   push:
     branches:
       - master
+  pull_request:
+    branches:
+      - master
 concurrency:
   group: codecov-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Closes #1313.

The coverage workflow now runs for pull requests targeting `master`, so `npm run coverage` executes before a change is merged.

The Codecov upload remains guarded by `github.ref == 'refs/heads/master'`. This deliberately follows the pattern already used by other Objectionary repositories: fork PRs get the coverage test job without requiring access to `CODECOV_TOKEN`, while trusted master runs still publish the report.

The workflow YAML parses successfully locally.
