### PR TITLE
#1314: Fail when Codecov upload fails

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -39,5 +39,5 @@ jobs:
           files: ./coverage/lcov.info
           flags: unittests
           name: codecov-umbrella
-          fail_ci_if_error: false
+          fail_ci_if_error: true
         if: github.ref == 'refs/heads/master'


### PR DESCRIPTION
Closes #1314.

The Codecov action now uses `fail_ci_if_error: true`, so the trusted master coverage job fails when Codecov rejects or cannot publish the coverage report instead of silently staying green.

The upload step is already restricted to `github.ref == 'refs/heads/master'`, where the repository token is available, so this does not make fork pull requests depend on a secret.

The workflow YAML parses successfully locally.
