### PR TITLE
#1295: Remove unused xmlhttprequest dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,8 +24,7 @@
         "relative": "^3.0.2",
         "saxon-js": "^2.7.0",
         "semver": "^7.7.2",
-        "sync-request": "^6.1.0",
-        "xmlhttprequest": "^1.8.0"
+        "sync-request": "^6.1.0"
       },
       "bin": {
         "eoc": "src/eoc.js"
@@ -6737,15 +6736,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
-      }
-    },
-    "node_modules/xmlhttprequest": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
-      "integrity": "sha512-58Im/U0mlVBLM38NdZjHyhuMtCqa61469k2YP/AaPbvCoV9aQGUpbJBj1QRm2ytRiVQBD/fsw7L2bJGDVQswBA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
       }
     },
     "node_modules/y18n": {

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "relative": "^3.0.2",
     "saxon-js": "^2.7.0",
     "semver": "^7.7.2",
-    "sync-request": "^6.1.0",
-    "xmlhttprequest": "^1.8.0"
+    "sync-request": "^6.1.0"
   },
   "description": "A collection of command line tools for EOLANG: compiling, parsing, transpiling to other languages, optimizing, and analyzing",
   "devDependencies": {


### PR DESCRIPTION
Closes #1295.

Removes the unused `xmlhttprequest` runtime dependency from both `package.json` and the lockfile. A repository-wide search excluding `node_modules` and `.git` finds no import or use of `xmlhttprequest`/`XMLHttpRequest`; after the change the lockfile has no `node_modules/xmlhttprequest` entry.

The lockfile update is limited to the root dependency entry and the package's own resolved block; no unrelated dependencies were updated.
