### PR TITLE
#1318: Pin xcop action to v1.3 commit

### DIFF
--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: g4s8/xcop-action@master
+      - uses: g4s8/xcop-action@4e93f123cab886ca8e481a737ee586bc9f02d228 # v1.3
         with:
           license: LICENSE.txt
           files: "**/*.xml"


### PR DESCRIPTION
Closes #1318.

Pins `g4s8/xcop-action` to immutable commit `4e93f123cab886ca8e481a737ee586bc9f02d228`, which is the commit tagged and released as `v1.3`.

That SHA is also the action repository's current `master`, so this removes the mutable dependency without changing the action code EOC currently executes. The workflow YAML parses successfully locally.
