### PR TITLE
#1317: Pin shellcheck action to release commit

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,4 +19,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: ludeeus/action-shellcheck@master
+      - uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # 2.0.0


### PR DESCRIPTION
Closes #1317.

Pins `ludeeus/action-shellcheck` to immutable commit `00cae500b08a931fb5698e11e79bfbd38e612a38`, tagged as release `2.0.0`.

I compared that release with the current upstream `master`: the commits after `2.0.0` change only the action repository's own workflows and README, not the action implementation. Thus the pin removes the mutable dependency without changing the ShellCheck behavior EOC currently relies on.

The workflow YAML parses successfully locally.
