### PR TITLE
#1319: Pin Telegram action to release commit

### DIFF
--- a/.github/workflows/grunt.yml
+++ b/.github/workflows/grunt.yml
@@ -70,7 +70,7 @@ jobs:
               | [ ., 0 ] | max')
           echo "This run took ${seconds} seconds"
           echo "seconds=${seconds}" >> "${GITHUB_OUTPUT}"
-      - uses: appleboy/telegram-action@master
+      - uses: appleboy/telegram-action@214f06cfa3d3a588c1472116889437e7c6fd29b1 # v1.1.1
         with:
           to: -1004371404002
           token: ${{ secrets.TELEGRAM_TOKEN }}
@@ -115,7 +115,7 @@ jobs:
             echo 'broken=yes' >> "${GITHUB_OUTPUT}"
           fi
       - if: ${{ steps.previous.outputs.broken == 'yes' }}
-        uses: appleboy/telegram-action@master
+        uses: appleboy/telegram-action@214f06cfa3d3a588c1472116889437e7c6fd29b1 # v1.1.1
         with:
           to: -1004371404002
           token: ${{ secrets.TELEGRAM_TOKEN }}

--- a/.github/workflows/telegram.yml
+++ b/.github/workflows/telegram.yml
@@ -28,7 +28,7 @@ jobs:
             printf 'It is advised to use this tool for all interactions with '
             printf 'EO compiler(s) and optimizers.'
           ) > message.md
-      - uses: appleboy/telegram-action@master
+      - uses: appleboy/telegram-action@214f06cfa3d3a588c1472116889437e7c6fd29b1 # v1.1.1
         with:
           to: -1001381878846
           token: ${{ secrets.TELEGRAM_TOKEN }}


### PR DESCRIPTION
Closes #1319.

Pins all three `appleboy/telegram-action` uses in `grunt.yml` and `telegram.yml` to immutable commit `214f06cfa3d3a588c1472116889437e7c6fd29b1`, tagged as release `v1.1.1`.

I compared `v1.1.1` with the current upstream `master`. The five later commits touch only the action repository's CI workflows and README files, not its runtime action implementation, so this removes the mutable ref without changing the Telegram behavior EOC currently executes.

Both modified workflow files parse successfully locally.
