### PR TITLE
#1316: Pin PDD action to immutable commit

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -16,4 +16,4 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v7
-      - uses: volodya-lombrozo/pdd-action@master
+      - uses: volodya-lombrozo/pdd-action@69842b56627431c5f232f5ea2dc2fca82f409c54 # master 2023-12-18


### PR DESCRIPTION
Closes #1316.

Pins `volodya-lombrozo/pdd-action` to immutable commit `69842b56627431c5f232f5ea2dc2fca82f409c54`, which is the current upstream `master` commit (2023-12-18).

The upstream action has no GitHub releases and no tags, so there is no release tag that can be documented without inventing one. Pinning the exact commit currently referenced by `master` preserves today's behavior while making the EOC check reproducible; the inline comment records the upstream date/version identity.

The workflow YAML parses successfully locally.
