### PR TITLE
#1315: Declare least-privilege workflow permissions

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -10,6 +10,8 @@ name: actionlint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   actionlint:
     timeout-minutes: 15

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -7,6 +7,8 @@ name: codecov
   push:
     branches:
       - master
+permissions:
+  contents: read
 concurrency:
   group: codecov-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/copyrights.yml
+++ b/.github/workflows/copyrights.yml
@@ -10,6 +10,8 @@ name: copyrights
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   copyrights:
     timeout-minutes: 15

--- a/.github/workflows/eo-version-up.yml
+++ b/.github/workflows/eo-version-up.yml
@@ -9,11 +9,16 @@ name: eo-version-up
       - master
     tags:
       - '*'
+permissions:
+  contents: read
 concurrency:
   group: eo-version-up-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   eo-version-up:
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/eslint.yml
+++ b/.github/workflows/eslint.yml
@@ -10,6 +10,8 @@ name: eslint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   eslint:
     timeout-minutes: 15

--- a/.github/workflows/grunt.yml
+++ b/.github/workflows/grunt.yml
@@ -12,6 +12,8 @@ name: grunt
       - master
   schedule:
     - cron: '0 4 * * *'
+permissions:
+  contents: read
 concurrency:
   group: grunt-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/homebrew-formula-up.yml
+++ b/.github/workflows/homebrew-formula-up.yml
@@ -6,11 +6,16 @@ name: homebrew-formulas-update
 'on':
   release:
     types: [published]
+permissions:
+  contents: read
 concurrency:
   group: homebrew-formula-up-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   update-formula:
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/itest.yml
+++ b/.github/workflows/itest.yml
@@ -12,6 +12,8 @@ name: itest
       - master
   schedule:
     - cron: '0 4 * * *'
+permissions:
+  contents: read
 concurrency:
   group: itest-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -10,6 +10,8 @@ name: markdown-lint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 concurrency:
   group: markdown-lint-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -10,6 +10,8 @@ name: nix
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 concurrency:
   group: nix-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -10,6 +10,8 @@ name: pdd
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   pdd:
     timeout-minutes: 15

--- a/.github/workflows/readme-automation.yml
+++ b/.github/workflows/readme-automation.yml
@@ -9,11 +9,16 @@ name: readme-automation
   push:
     paths:
       - "src/eoc.js"
+permissions:
+  contents: read
 concurrency:
   group: readmeautomation-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   build:
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -10,6 +10,8 @@ name: reuse
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   reuse:
     timeout-minutes: 15

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -10,6 +10,8 @@ name: shellcheck
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 concurrency:
   group: shellcheck-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/telegram.yml
+++ b/.github/workflows/telegram.yml
@@ -7,6 +7,8 @@ name: telegram
   push:
     tags:
       - '*'
+permissions:
+  contents: read
 concurrency:
   group: telegram-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/titles.yml
+++ b/.github/workflows/titles.yml
@@ -8,8 +8,13 @@ name: titles
     - cron: '0 * * * *'
   issues:
     types: [opened]
+permissions:
+  contents: read
 jobs:
   titles:
+    permissions:
+      contents: read
+      issues: write
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/typos.yml
+++ b/.github/workflows/typos.yml
@@ -10,6 +10,8 @@ name: typos
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   typos:
     timeout-minutes: 15

--- a/.github/workflows/up.yml
+++ b/.github/workflows/up.yml
@@ -9,11 +9,16 @@ name: up
       - master
     tags:
       - '*'
+permissions:
+  contents: read
 concurrency:
   group: up-${{ github.ref }}
   cancel-in-progress: true
 jobs:
   up:
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 15
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/xcop.yml
+++ b/.github/workflows/xcop.yml
@@ -10,6 +10,8 @@ name: xcop
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   xcop:
     timeout-minutes: 15

--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -10,6 +10,8 @@ name: yamllint
   pull_request:
     branches:
       - master
+permissions:
+  contents: read
 jobs:
   yamllint:
     timeout-minutes: 15


### PR DESCRIPTION
Closes #1315.

Declares explicit least-privilege `GITHUB_TOKEN` permissions across every workflow:

- read-only workflows receive `contents: read`;
- the four jobs using `peter-evans/create-pull-request` receive only `contents: write` and `pull-requests: write`;
- the issue-title automation receives `contents: read` and `issues: write` because it updates issue metadata;
- the existing Grunt notification jobs retain their narrower `actions: read` job permissions.

This prevents repository-wide token-default changes from silently granting unrelated CI jobs write access while preserving the scopes used by the automation jobs that actually mutate repository state.

Validation: all workflow files parse successfully as YAML and `git diff --check` is clean.
