### PR TITLE
#1310: Isolate Maven progress state per run

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -32,11 +32,6 @@ function shell() {
   }
 }
 
-let beginning,
-  phase = 'unknown',
-  running = false,
-  target;
-
 /**
  * Prepare options for Maven.
  * @param {Object} opts - Opts provided to the "eoc"
@@ -87,13 +82,18 @@ module.exports.flags = function(opts) {
  * @param {Array.<String>} args - All arguments to pass to it
  * @param {String} [tgt] - Path to the target directory
  * @param {Boolean} [batch] - Is it batch mode (TRUE) or interactive (FALSE)?
+ * @param {Function} [runner] - Optional Maven process runner
  * @return {Promise} of maven execution task
  */
-module.exports.mvnw = function(args, tgt, batch) {
+module.exports.mvnw = function(args, tgt, batch, runner = spawn) {
   return new Promise((resolve, reject) => {
     console.debug(`Running mvnw with arguments: ${args.join(' ')}`);
-    target = tgt;
-    phase = module.exports.summary(args);
+    const progress = {
+      beginning: 0,
+      phase: module.exports.summary(args),
+      running: false,
+      target: tgt,
+    };
     const home = path.resolve(__dirname, '../mvnw');
     let bin = path.resolve(home, 'mvnw') + (process.platform === 'win32' ? '.cmd' : '');
     if (!fs.existsSync(bin)) {
@@ -110,7 +110,7 @@ module.exports.mvnw = function(args, tgt, batch) {
     ]);
     const cmd = `${bin} ${params.join(' ')}`;
     console.debug('+ %s', cmd);
-    const result = spawn(
+    const result = runner(
       bin,
       process.platform === 'win32' ? params.map((p) => `"${p}"`) : params,
       {
@@ -121,11 +121,11 @@ module.exports.mvnw = function(args, tgt, batch) {
     );
     if (tgt !== undefined && args.includes('--quiet')) {
       if (!batch) {
-        start();
+        start(progress);
       }
       result.on('close', (code) => {
         if (!batch) {
-          stop();
+          stop(progress);
         }
         if (code !== 0) {
           reject(new Error(`The command "${cmd}" exited with #${code} code`));
@@ -148,12 +148,12 @@ module.exports.mvnw = function(args, tgt, batch) {
 /**
  * Starts mvnw execution status detection.
  */
-function start() {
-  running = true;
-  beginning = Date.now();
+function start(progress) {
+  progress.running = true;
+  progress.beginning = Date.now();
   const check = function() {
-    if (running) {
-      print();
+    if (progress.running) {
+      print(progress);
       setTimeout(check, 1000);
     }
   };
@@ -163,16 +163,16 @@ function start() {
 /**
  * Stops mvnw execution status detection.
  */
-function stop() {
-  running = false;
+function stop(progress) {
+  progress.running = false;
   readline.clearLine(process.stdout);
 }
 
 /**
  * Prints mvnw execution status.
  */
-function print() {
-  const duration = Date.now() - beginning;
+function print(progress) {
+  const duration = Date.now() - progress.beginning;
   /**
    * Recursively calculates number of files under a directory.
    * @param {String} dir - Directory where to count.
@@ -219,7 +219,9 @@ function print() {
     elapsed = `${Math.ceil(duration / (60 * 1000))}min`;
   }
   process.stdout.write(
-    colors.yellow(`[${phase}] ${elapsed}; ${count(target, 0)} files generated so far...`)
+    colors.yellow(
+      `[${progress.phase}] ${elapsed}; ${count(progress.target, 0)} files generated so far...`
+    )
   );
   readline.clearLine(process.stdout, 1);
   readline.cursorTo(process.stdout, 0);

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -9,6 +9,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const {execSync} = require('child_process');
+const {EventEmitter} = require('events');
 
 describe('mvnw', () => {
   it('prints Maven own version', async () => {
@@ -110,6 +111,51 @@ describe('mvnw', () => {
     await assert.rejects(mvnw(['--unrecognized-eoc-flag', '--quiet'], null, true));
     const args = await mvnw(['--version', '--quiet'], null, true);
     assert.ok(args.includes('--version'), 'mvnw cannot run again, the process did not survive a failed run');
+  });
+  it('keeps concurrent progress state independent', async function () {
+    this.timeout(5000);
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'eoc-mvnw-concurrent-'));
+    const first = path.join(home, 'first');
+    const second = path.join(home, 'second');
+    fs.mkdirSync(first);
+    fs.mkdirSync(second);
+    fs.writeFileSync(path.join(first, 'one'), '1');
+    fs.writeFileSync(path.join(second, 'one'), '1');
+    fs.writeFileSync(path.join(second, 'two'), '2');
+    const children = [];
+    const runner = () => {
+      const child = new EventEmitter();
+      children.push(child);
+      return child;
+    };
+    const output = [];
+    const before = process.stdout.write;
+    process.stdout.write = (chunk) => {
+      output.push(String(chunk));
+      return true;
+    };
+    try {
+      const initial = mvnw(['first-goal', '--quiet'], first, false, runner);
+      const latter = mvnw(['second-goal', '--quiet'], second, false, runner);
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+      const firstTicks = output.filter((line) => line.includes('[first-goal]')).length;
+      const secondTicks = output.filter((line) => line.includes('[second-goal]')).length;
+      assert(firstTicks >= 2, 'first Maven invocation lost its own progress state');
+      assert(secondTicks >= 2, 'second Maven invocation lost its own progress state');
+      children[0].emit('close', 0);
+      await initial;
+      const ticks = output.filter((line) => line.includes('[second-goal]')).length;
+      await new Promise((resolve) => setTimeout(resolve, 1100));
+      assert(
+        output.filter((line) => line.includes('[second-goal]')).length > ticks,
+        'finishing one Maven invocation stopped another progress ticker'
+      );
+      children[1].emit('close', 0);
+      await latter;
+    } finally {
+      process.stdout.write = before;
+      fs.rmSync(home, {recursive: true, force: true});
+    }
   });
   it('collapses several Maven goals into a count', () => {
     assert.strictEqual(


### PR DESCRIPTION
Closes #1310.

Moves Maven progress state from module-level variables into an object created for each `mvnw()` invocation. `start`, `print`, and `stop` now operate on that invocation's state, so concurrent runs cannot overwrite each other's phase/target or stop each other's ticker.

The optional process runner parameter is only for deterministic testing and defaults to the existing `spawn`, preserving callers.

Added a regression test with two independent `EventEmitter` child processes and targets containing different file counts. It verifies both tickers continue with their own labels, then closes the first process and proves the second ticker keeps running.

Validation:
- `npx eslint src/mvnw.js test/test_mvnw.js`
- focused Mocha regression test
- `git diff --check`

All pass locally.
