### PR TITLE
#1147: Link generated docs stylesheet relatively

### DIFF
--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -117,6 +117,16 @@ function wrapHtml(name, html, css) {
 }
 
 /**
+ * Create a browser-safe relative link from one generated file to another.
+ * @param {String} source - Generated HTML file path
+ * @param {String} target - Linked asset path
+ * @return {String} Relative URL using forward slashes
+ */
+function relativeHref(source, target) {
+  return path.relative(path.dirname(source), target).split(path.sep).join('/');
+}
+
+/**
  * Command to generate documentation.
  * @param {Hash} opts - All options
  * @return {Promise<String>} Resolves to the message reporting the summary path
@@ -138,7 +148,10 @@ module.exports = function(opts) {
         const xmir_html = createXmirHtmlBlock(xmir);
         const html_app = path.join(output, path.dirname(relative),`${name}.html`);
         fs.mkdirSync(path.dirname(html_app), {recursive: true});
-        fs.writeFileSync(html_app, wrapHtml(name, xmir_html, css));
+        fs.writeFileSync(
+          html_app,
+          wrapHtml(name, xmir_html, relativeHref(html_app, css))
+        );
         const package_dir = path.dirname(relative);
         if (package_dir !== '.') {
           const package_name = package_dir.split(path.sep).join('.');
@@ -161,10 +174,15 @@ module.exports = function(opts) {
       for (const [package_name, info] of packages_info) {
         fs.mkdirSync(path.dirname(info.path), {recursive: true});
         fs.writeFileSync(info.path,
-          generatePackageHtml(`${package_name} package`, info.xmir_htmls, css));
+          generatePackageHtml(
+            `${package_name} package`, info.xmir_htmls, relativeHref(info.path, css)
+          ));
       }
       const packages = path.join(output, 'packages.html');
-      fs.writeFileSync(packages, generatePackageHtml('overall package', all_xmir_htmls, css));
+      fs.writeFileSync(
+        packages,
+        generatePackageHtml('overall package', all_xmir_htmls, relativeHref(packages, css))
+      );
       const summary = path.join(output, 'summary.xml');
       const lines = [
         '<?xml version="1.0" encoding="UTF-8"?>',

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -45,6 +45,18 @@ describe('docs', () => {
     assert(fs.existsSync(packages_html), `Expected file ${packages_html} but it was not created`);
     const css_html = path.join(docs, 'styles.css');
     assert(fs.existsSync(css_html), `Expected file ${css_html} but it was not created`);
+    assert(
+      fs.readFileSync(test1_html, 'utf-8').includes('href="../../styles.css"'),
+      'Nested object page must link the stylesheet relative to its own directory'
+    );
+    assert(
+      fs.readFileSync(package_foo_bar_html, 'utf-8').includes('href="styles.css"'),
+      'Root package page must link the stylesheet without an absolute filesystem path'
+    );
+    assert(
+      fs.readFileSync(packages_html, 'utf-8').includes('href="styles.css"'),
+      'Package index must link the stylesheet relatively'
+    );
     done();
   });
   /**


### PR DESCRIPTION
Closes #1147.

Generated HTML now receives a stylesheet href relative to the HTML file itself instead of the absolute local path to `styles.css`. The helper also normalizes the result to `/`, so generated links remain valid URLs on Windows.

This handles each output depth independently:
- nested object pages link back through the required `../` segments;
- package pages and `packages.html`, which live beside `styles.css`, use `styles.css` directly.

The existing docs regression now checks the actual hrefs for both nested and root-level generated pages, so an absolute filesystem path or a depth-insensitive link will fail the test.

Validation on current master:
- `npx eslint src/commands/docs.js test/commands/test_docs.js`
- `npx mocha test/commands/test_docs.js --grep 'generates HTML files for files and packages' --timeout 120000`
- `git diff --check`

All pass locally. This is a clean current-master replacement for the closed/stale #1152; it does not reuse that PR's malformed diff markers.
