### PR TITLE
#1308: Run fallback Maven from caller directory

### DIFF
--- a/src/mvnw.js
+++ b/src/mvnw.js
@@ -83,6 +83,22 @@ module.exports.flags = function(opts) {
 };
 
 /**
+ * Resolve Maven executable and its working directory.
+ * @param {String} home - Directory containing the bundled wrapper
+ * @return {Object} Maven binary and working directory
+ */
+module.exports.maven = function(home) {
+  let bin = path.resolve(home, 'mvnw') + (process.platform === 'win32' ? '.cmd' : '');
+  let cwd = home;
+  if (!fs.existsSync(bin)) {
+    console.warn(colors.yellow(`Warning: mvnw not found at ${bin}, falling back to system "mvn"`));
+    bin = 'mvn';
+    cwd = process.cwd();
+  }
+  return {bin, cwd};
+};
+
+/**
  * Run mvnw with provided commands.
  * @param {Array.<String>} args - All arguments to pass to it
  * @param {String} [tgt] - Path to the target directory
@@ -95,11 +111,8 @@ module.exports.mvnw = function(args, tgt, batch) {
     target = tgt;
     phase = module.exports.summary(args);
     const home = path.resolve(__dirname, '../mvnw');
-    let bin = path.resolve(home, 'mvnw') + (process.platform === 'win32' ? '.cmd' : '');
-    if (!fs.existsSync(bin)) {
-      console.warn(colors.yellow(`Warning: mvnw not found at ${bin}, falling back to system "mvn"`));
-      bin = 'mvn';
-    }
+    const maven = module.exports.maven(home);
+    const bin = maven.bin;
     const params = args.filter((t) => t !== '').concat([
       '--batch-mode',
       '--color=never',
@@ -114,7 +127,7 @@ module.exports.mvnw = function(args, tgt, batch) {
       bin,
       process.platform === 'win32' ? params.map((p) => `"${p}"`) : params,
       {
-        cwd: home,
+        cwd: maven.cwd,
         stdio: 'inherit',
         shell: shell(),
       }

--- a/test/test_mvnw.js
+++ b/test/test_mvnw.js
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: MIT
  */
 
-const {mvnw, flags, summary} = require('../src/mvnw');
+const {mvnw, flags, summary, maven} = require('../src/mvnw');
 const assert = require('assert');
 const fs = require('fs');
 const os = require('os');
@@ -11,6 +11,18 @@ const path = require('path');
 const {execSync} = require('child_process');
 
 describe('mvnw', () => {
+  it('runs system Maven from the caller working directory when wrapper is absent', () => {
+    const home = path.join(os.tmpdir(), 'eoc-missing-mvnw');
+    const selected = maven(home);
+    assert.strictEqual(selected.bin, 'mvn', 'system Maven was not selected without the wrapper');
+    assert.strictEqual(selected.cwd, process.cwd(), 'system Maven did not keep the caller working directory');
+  });
+  it('runs bundled Maven wrapper from its own directory', () => {
+    const home = path.resolve(__dirname, '../mvnw');
+    const selected = maven(home);
+    assert.notStrictEqual(selected.bin, 'mvn', 'bundled Maven wrapper was not selected');
+    assert.strictEqual(selected.cwd, home, 'bundled wrapper did not run from its own directory');
+  });
   it('prints Maven own version', async () => {
     const opts = {batch: true};
     await mvnw(['--version', '--quiet'], null, opts.batch);


### PR DESCRIPTION
Closes #1308.

When the bundled wrapper is unavailable, system `mvn` now keeps the caller's current working directory instead of inheriting the eoc package's internal `mvnw/` directory. The bundled wrapper still runs from its own directory as before.

The executable/cwd selection is factored into `maven()` so both branches are regression-tested. The tests verify that a missing wrapper selects `mvn` with `process.cwd()`, while an existing bundled wrapper keeps its wrapper directory.

Validation performed locally:
- `npx mocha test/test_mvnw.js --timeout 1200000` — passed;
- `npx eslint src/mvnw.js test/test_mvnw.js` — passed;
- `git diff --check` — clean.
