### PR TITLE
#1267: Escape generated documentation titles

### DIFF
--- a/src/commands/docs.js
+++ b/src/commands/docs.js
@@ -95,7 +95,7 @@ function generatePackageHtml(name, htmls, css) {
         <section>
           <header>
             <nav>
-              <h1>${name} documentation</h1>
+              <h1>${xmlEscape(name)} documentation</h1>
               <p>Creation date: ${date.toUTCString()}</p>
             </nav>
           </header>

--- a/test/commands/test_docs.js
+++ b/test/commands/test_docs.js
@@ -111,6 +111,32 @@ describe('docs', () => {
     done();
   });
   /**
+   * Tests that object and package names are escaped before HTML interpolation.
+   * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
+   */
+  it('escapes object and package names in generated HTML', (done) => {
+    const sample = path.join(parsed, 'foo&bar');
+    fs.mkdirSync(sample, {recursive: true});
+    fs.writeFileSync(path.join(sample, 'a&b.xmir'), '<program name="test" />');
+    runSync([
+      'docs',
+      '--verbose',
+      '-s', path.resolve(home, 'src'),
+      '-t', home,
+    ]);
+    const object = fs.readFileSync(path.join(docs, 'foo&bar/a&b.html'), 'utf-8');
+    assert(
+      object.includes('<h1>a&amp;b documentation</h1>'),
+      'object name was interpolated into HTML without escaping'
+    );
+    const pkg = fs.readFileSync(path.join(docs, 'package_foo&bar.html'), 'utf-8');
+    assert(
+      pkg.includes('<h1>foo&amp;bar package documentation</h1>'),
+      'package name was interpolated into HTML without escaping'
+    );
+    done();
+  });
+  /**
    * Tests that the 'docs' command generates a summary.xml with correct counts.
    * @param {Mocha.Done} done - Mocha callback signaling asynchronous completion
    */


### PR DESCRIPTION
Closes #1267.

Escapes object/package names before interpolating them into the generated HTML `<h1>`. The existing `xmlEscape()` helper is already used for the same names in `summary.xml`; for element text it provides the required escaping for `&`, `<` and `>` (and safely escapes quotes as well).

Added a cross-platform regression using an object `a&b.xmir` inside package directory `foo&bar`. It verifies the object page contains `a&amp;b` and the package page contains `foo&amp;bar` rather than raw ampersands.

Validation:
- `npx eslint src/commands/docs.js test/commands/test_docs.js`
- focused Mocha test for escaped names
- `git diff --check`

All pass locally.
